### PR TITLE
Improve loading of advisories

### DIFF
--- a/notus/scanner/errors.py
+++ b/notus/scanner/errors.py
@@ -1,0 +1,24 @@
+# Copyright (C) 2021 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+class NotusScannerError(Exception):
+    """Base Class for error raised in Notus Scanner"""
+
+
+class AdvisoriesLoadingError(NotusScannerError):
+    """A problem while loading an Advisory has occurred"""

--- a/notus/scanner/loader/csv.py
+++ b/notus/scanner/loader/csv.py
@@ -35,13 +35,23 @@ from .loader import AdvisoriesLoader
 logger = logging.getLogger(__name__)
 
 
+def _get_os_name(operating_system: str):
+    """Simple helper function to get the OS name from a full os release
+
+    The function just assumes that the OS name is the first string in the full
+    name and afterwards a version follows. This should be true for the current
+    supported operating systems.
+    """
+    return operating_system[: operating_system.find(" ")]
+
+
 class CsvAdvisoriesLoader(AdvisoriesLoader):
     def __init__(self, advisories_directory_path: Path):
         self._advisories_directory_path = advisories_directory_path
 
     def load(self, operating_system: str) -> PackageAdvisories:
-        # hardcode CSV file for now because we don't support other OS yet
-        csv_file_path = self._advisories_directory_path / "EulerOS.csv"
+        os_name = _get_os_name(operating_system)
+        csv_file_path = self._advisories_directory_path / f"{os_name}.csv"
         if not csv_file_path.is_file():
             logger.error(
                 'Could not load advisories from %s. File does not exist.',

--- a/notus/scanner/loader/csv.py
+++ b/notus/scanner/loader/csv.py
@@ -23,6 +23,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List
 
+from ..errors import AdvisoriesLoadingError
 from ..models.advisory import (
     OperatingSystemAdvisories,
     Advisory,
@@ -52,12 +53,11 @@ class CsvAdvisoriesLoader(AdvisoriesLoader):
     def load(self, operating_system: str) -> PackageAdvisories:
         os_name = _get_os_name(operating_system)
         csv_file_path = self._advisories_directory_path / f"{os_name}.csv"
-        if not csv_file_path.is_file():
-            logger.error(
-                'Could not load advisories from %s. File does not exist.',
-                str(csv_file_path),
+        if not csv_file_path.exists():
+            raise AdvisoriesLoadingError(
+                f'Could not load advisories from {csv_file_path}. '
+                'File does not exist.'
             )
-            return
 
         with csv_file_path.open('r') as raw_csv_file:
             # Skip the license header, so the actual

--- a/notus/scanner/loader/csv.py
+++ b/notus/scanner/loader/csv.py
@@ -39,7 +39,7 @@ class CsvAdvisoriesLoader(AdvisoriesLoader):
     def __init__(self, csv_file: Path):
         self._csv_file = csv_file
 
-    def load(self) -> OperatingSystemAdvisories:
+    def load(self, operating_system: str) -> PackageAdvisories:
         with self._csv_file.open() as raw_csv_file:
             # Skip the license header, so the actual
             # content can be parsed by the DictReader
@@ -108,4 +108,6 @@ class CsvAdvisoriesLoader(AdvisoriesLoader):
                         os_name, package_advisories
                     )
 
-                return operating_system_advisories
+                return operating_system_advisories.get_package_advisories(
+                    operating_system
+                )

--- a/notus/scanner/loader/loader.py
+++ b/notus/scanner/loader/loader.py
@@ -15,9 +15,9 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-from ..models.advisory import OperatingSystemAdvisories
+from ..models.advisory import PackageAdvisories
 
 
 class AdvisoriesLoader:
-    def load(self) -> OperatingSystemAdvisories:
+    def load(self, operating_system: str) -> PackageAdvisories:
         raise NotImplementedError()

--- a/notus/scanner/scanner.py
+++ b/notus/scanner/scanner.py
@@ -41,10 +41,7 @@ class NotusScan:
         operating_system: str,
         installed_packages: List[Package],
     ) -> Generator[PackageVulnerability, None, None]:
-        operating_system_advisories = self._advisories_loader.load()
-        package_advisories = operating_system_advisories.get_package_advisories(
-            operating_system
-        )
+        package_advisories = self._advisories_loader.load(operating_system)
 
         for package in installed_packages:
             package_advisory_list = (

--- a/notus/scanner/scanner.py
+++ b/notus/scanner/scanner.py
@@ -64,16 +64,9 @@ class NotusScanner:
         metadata_directory: Path,
         publisher: Publisher,
     ):
-        # hardcode CSV file for now because we don't support other OS yet
-        csv_file_path = metadata_directory / "EulerOS.csv"
-        if not csv_file_path.is_file():
-            logger.error(
-                'Could not load advisories from %s. File does not exist.',
-                str(csv_file_path),
-            )
-            return
-
-        self._loader = CsvAdvisoriesLoader(csv_file_path)
+        self._loader = CsvAdvisoriesLoader(
+            advisories_directory_path=metadata_directory
+        )
         self._publisher = publisher
 
     def _finish_host(self, scan_id: str, host_ip: str):


### PR DESCRIPTION
**What**:

Change the loader to load the package advisories for an operating system. Raise new exception of advisories couldn't be loaded.

**Why**:

Make the loading of advisories more robust against failures and update loading interface for the future JSON files.

SC-362

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- n/a Tests
- n/a [CHANGELOG](https://github.com/greenbone/notus-scanner/blob/master/CHANGELOG.md) Entry
- n/a Documentation
