### PR TITLE
Add scripts for testing the notus-scanner functionality

### DIFF
--- a/notus/scanner/cli/parser.py
+++ b/notus/scanner/cli/parser.py
@@ -32,6 +32,16 @@ Arguments = argparse.Namespace
 logger = logging.getLogger(__name__)
 
 
+def log_level(string: str) -> str:
+    """Check if provided string is a valid log level."""
+
+    if not hasattr(logging, string.upper()):
+        raise argparse.ArgumentTypeError(
+            'log level must be one of {debug,info,warning,error,critical}'
+        )
+    return string.upper()
+
+
 def _dir_path(directory: str) -> Path:
     """Check if a given string is a valid path to a directory,
     relative or absolute.
@@ -89,7 +99,7 @@ class CliParser:
             '-L',
             '--log-level',
             default='INFO',
-            type=self.log_level,
+            type=log_level,
             help='Wished level of logging (default: %(default)s)',
         )
         parser.add_argument(
@@ -123,15 +133,6 @@ class CliParser:
         )
 
         self.parser = parser
-
-    def log_level(self, string: str) -> str:
-        """Check if provided string is a valid log level."""
-
-        if not hasattr(logging, string.upper()):
-            raise argparse.ArgumentTypeError(
-                'log level must be one of {debug,info,warning,error,critical}'
-            )
-        return string.upper()
 
     def _set_defaults(self, configfilename=None) -> None:
         self._config = self._load_config(configfilename)

--- a/notus/scanner/scanner.py
+++ b/notus/scanner/scanner.py
@@ -95,8 +95,7 @@ class NotusScanner:
     ) -> None:
         report = f"""Vulnerable package: {vulnerability.package.name}
 Installed version: {vulnerability.package.full_name}
-Fixed version: {vulnerability.fixed_package.full_name}
-"""
+Fixed version: {vulnerability.fixed_package.full_name}"""
         message = ResultMessage(
             scan_id=scan_id,
             host_ip=vulnerability.host_ip,

--- a/notus/scanner/tools/scanstart.py
+++ b/notus/scanner/tools/scanstart.py
@@ -1,0 +1,128 @@
+# Copyright (C) 2021 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+import argparse
+import logging
+
+from pathlib import Path
+from uuid import uuid4
+
+from ..cli.parser import DEFAULT_MQTT_BROKER_PORT, log_level
+from ..messages.start import ScanStartMessage
+from ..messaging.mqtt import MQTTClient, MQTTPublisher
+
+
+def after_publish(client, _userdata, _mid):
+    client.disconnect()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="A test client to start generating scan results via the "
+        "Notus Scanner"
+    )
+    parser.add_argument(
+        "-b",
+        "--mqtt-broker-address",
+        type=str,
+        required=True,
+        help="Hostname or IP address of the MQTT broker.",
+    )
+    parser.add_argument(
+        "-p",
+        "--mqtt-broker-port",
+        type=int,
+        default=DEFAULT_MQTT_BROKER_PORT,
+        help="Port of the MQTT broker. (default: %(default)s)",
+    )
+    parser.add_argument(
+        "-s",
+        "--scan-id",
+        help="ID to use for the scan. If no scan ID is provided a random ID "
+        "will be generated",
+    )
+    parser.add_argument(
+        "--host-ip",
+        required=True,
+        help="IP address of the host to report in generated results",
+    )
+    parser.add_argument(
+        "--host-name", help="Name of the host to report in generated results"
+    )
+    parser.add_argument(
+        "--os-release",
+        required=True,
+        help="Name of the Operating System Release to scan",
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--packages",
+        nargs="+",
+        help="List of packages to compare for vulnerabilities",
+    )
+    group.add_argument(
+        "--package-file",
+        type=Path,
+        help="Path to a file containing a list of packages to compare for "
+        "vulnerabilities",
+    )
+    parser.add_argument(
+        '-L',
+        '--log-level',
+        default='INFO',
+        type=log_level,
+        help='Wished level of logging (default: %(default)s)',
+    )
+
+    args = parser.parse_args()
+
+    logging.basicConfig(level=args.log_level)
+
+    scan_id = args.scan_id or str(uuid4())
+    if args.packages:
+        package_list = args.packages
+    else:
+        package_file_path: Path = args.package_file
+        with package_file_path.open("r", encoding="utf8") as f:
+            package_list = f.readlines()
+
+    print(f"Starting a scan with ID {scan_id}")
+
+    start_scan_message = ScanStartMessage(
+        scan_id=scan_id,
+        host_ip=args.host_ip,
+        host_name=args.host_name,
+        os_release=args.os_release,
+        package_list=package_list,
+    )
+    client = MQTTClient(
+        mqtt_broker_address=args.mqtt_broker_address,
+        mqtt_broker_port=args.mqtt_broker_port,
+        client_id=f"notus-scan-start-{scan_id}",
+    )
+    client.on_publish = after_publish
+    client.connect()
+    client.loop()
+
+    publisher = MQTTPublisher(client)
+    publisher.publish(start_scan_message)
+
+    client.loop_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/notus/scanner/tools/subscriber.py
+++ b/notus/scanner/tools/subscriber.py
@@ -1,0 +1,107 @@
+# Copyright (C) 2021 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+import argparse
+import atexit
+import logging
+import signal
+
+from functools import partial
+
+from ..cli.parser import DEFAULT_MQTT_BROKER_PORT, log_level
+from ..messaging.mqtt import MQTTClient, MQTTSubscriber
+from ..messages.status import ScanStatusMessage
+from ..messages.result import ResultMessage
+
+
+def print_scan_status(message: ScanStatusMessage):
+    print("Scan Status")
+    print("-----------")
+    print(message.status)
+    print("-----------\n")
+
+
+def print_result_message(message: ResultMessage):
+    print("Scan Result")
+    print("-----------")
+    print(f"OID {message.oid}")
+    print(f"Host {message.host_ip} {message.host_name or ''}")
+    print(message.value)
+    print("-----------\n")
+
+
+def disconnect(
+    client: MQTTClient,
+    _signum=None,
+    _frame=None,
+) -> None:
+    client.disconnect()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="A test client to show messages created by the Notus "
+        "Scanner"
+    )
+    parser.add_argument(
+        "-b",
+        "--mqtt-broker-address",
+        type=str,
+        required=True,
+        help="Hostname or IP address of the MQTT broker.",
+    )
+    parser.add_argument(
+        "-p",
+        "--mqtt-broker-port",
+        type=int,
+        default=DEFAULT_MQTT_BROKER_PORT,
+        help="Port of the MQTT broker. (default: %(default)s)",
+    )
+    parser.add_argument(
+        '-L',
+        '--log-level',
+        default='INFO',
+        type=log_level,
+        help='Wished level of logging (default: %(default)s)',
+    )
+
+    args = parser.parse_args()
+
+    logging.basicConfig(level=args.log_level)
+
+    client = MQTTClient(
+        mqtt_broker_address=args.mqtt_broker_address,
+        mqtt_broker_port=args.mqtt_broker_port,
+        client_id="notus-subscriber",
+    )
+    client.connect()
+
+    subscriber = MQTTSubscriber(client)
+    subscriber.subscribe(ScanStatusMessage, print_scan_status)
+    subscriber.subscribe(ResultMessage, print_result_message)
+
+    disconnect_func = partial(disconnect, client)
+
+    atexit.register(disconnect_func, client)
+    signal.signal(signal.SIGTERM, disconnect_func)
+    signal.signal(signal.SIGINT, disconnect_func)
+
+    client.loop_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,8 @@ pontos = "^21.7.4"
 
 [tool.poetry.scripts]
 notus-scanner = "notus.scanner.daemon:main"
+notus-scan-start = "notus.scanner.tools.scanstart:main"
+notus-subscriber = "notus.scanner.tools.subscriber:main"
 
 [tool.black]
 line-length = 80


### PR DESCRIPTION
**What**:

Add a notus-start-scant and notus-subscriber tools for testing the notus-scanner functionality.

* notus-start-scan allows to issue a scan start message that initiates the notus scan.
* notus-subscriber prints the status and result messages issued by the notus scanner

SC-365

**Why**:

Easier testing and debugging.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/notus-scanner/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
