### PR TITLE
Adjust the start scan message topic

### DIFF
--- a/notus/scanner/messages/start.py
+++ b/notus/scanner/messages/start.py
@@ -24,7 +24,7 @@ from .message import Message, MessageType
 
 class ScanStartMessage(Message):
     message_type: MessageType = MessageType.SCAN_START
-    topic = "scanner/start"
+    topic = "scanner/package/cmd/notus"
 
     scan_id: str
     host_ip: str

--- a/tests/messages/test_start.py
+++ b/tests/messages/test_start.py
@@ -39,7 +39,7 @@ class ScanStartMessageTestCase(TestCase):
         self.assertIsInstance(message.created, datetime)
 
         self.assertEqual(message.message_type, MessageType.SCAN_START)
-        self.assertEqual(message.topic, 'scanner/start')
+        self.assertEqual(message.topic, 'scanner/package/cmd/notus')
 
         self.assertEqual(message.scan_id, 'scan_1')
         self.assertEqual(message.host_ip, '1.1.1.1')
@@ -109,7 +109,7 @@ class ScanStartMessageTestCase(TestCase):
         self.assertEqual(message.os_release, 'BarOS 1.0')
         self.assertEqual(message.package_list, ['foo-1.2.3-1.x86_64'])
 
-        self.assertEqual(message.topic, 'scanner/start')
+        self.assertEqual(message.topic, 'scanner/package/cmd/notus')
 
     def test_deserialize_invalid_message_type(self):
         data = {

--- a/tests/messaging/__init__.py
+++ b/tests/messaging/__init__.py
@@ -1,0 +1,16 @@
+# Copyright (C) 2021 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.

--- a/tests/messaging/test_mqtt.py
+++ b/tests/messaging/test_mqtt.py
@@ -50,7 +50,7 @@ class MQTTPublisherTestCase(TestCase):
         publisher.publish(message)
 
         client.publish.assert_called_with(
-            'scanner/start',
+            'scanner/package/cmd/notus',
             '{"message_id": "63026767-029d-417e-9148-77f4da49f49a", '
             '"message_type": "scan.start", '
             '"group_id": "866350e8-1492-497e-b12b-c079287d51dd", '
@@ -82,7 +82,7 @@ class MQTTSubscriberTestCase(TestCase):
 
         subscriber.subscribe(message, callback)
 
-        client.subscribe.assert_called_with('scanner/start', qos=1)
+        client.subscribe.assert_called_with('scanner/package/cmd/notus', qos=1)
 
 
 class MQTTDaemonTestCase(TestCase):


### PR DESCRIPTION
**What**:

Use "scanner/package/cmd/notus" from the latest spec.

SC-370

**Why**:

It has been adjusted to fit better into the eulabeia topic schema.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/notus-scanner/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
