### PR TITLE
Fix: strip architecture string before resolving

### DIFF
--- a/notus/scanner/models/package.py
+++ b/notus/scanner/models/package.py
@@ -93,7 +93,7 @@ class RPMPackage:
                 full_name
             ).groups()
             try:
-                arch = Architecture(architecture)
+                arch = Architecture(architecture.strip())
             except ValueError:
                 arch = Architecture.UNKNOWN
         except AttributeError:
@@ -127,7 +127,7 @@ class RPMPackage:
         ).groups()
 
         try:
-            arch = Architecture(architecture)
+            arch = Architecture(architecture.strip())
         except ValueError:
             arch = Architecture.UNKNOWN
 

--- a/tests/models/test_package.py
+++ b/tests/models/test_package.py
@@ -283,6 +283,9 @@ class RPMPackageTestCase(TestCase):
             package.full_name, "perl-Pod-Escapes-1.04-285.h2.noarch"
         )
 
+        package = RPMPackage.from_full_name(" libtool-ltdl-2.4.2-21.x86_64\r\n")
+        self.assertEqual(package.arch, Architecture.X86_64)
+
     def test_from_name_and_full_version(self):
         """it should be possible to create packages from name and full
         version"""


### PR DESCRIPTION
**What**:
Strip the architecture string before resolving it into a Enum.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
For some reason, when parsing package information, the architecture string contained an invisible `\r` at the end. The `strip()` method will remove it, if this is the case.

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/notus-scanner/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
