### PR TITLE
Fix: on_disconnect method for mqtt

### DIFF
--- a/notus/scanner/messaging/mqtt.py
+++ b/notus/scanner/messaging/mqtt.py
@@ -151,7 +151,7 @@ class MQTTDaemon:
             logger.error("Failed to connect to broker. Reason code %s", rc)
 
     @staticmethod
-    def on_disconnect(client, _userdata, rc=0):
+    def on_disconnect(client, _userdata, rc, _properties):
         logger.info("Disconnected from broker. Reason code %s", rc)
         client.loop_stop()
 


### PR DESCRIPTION
**What**:
Fix `on_disconnect` of mqtt module.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
When the mqtt broker shuts down while the notus-scanner is running a error occurs:
```
TypeError: on_disconnect() takes from 2 to 3 positional arguments but 4 were given
```

<!-- Why are these changes necessary? -->

**How**:
1. Start broker
2. Start notus-scanner
3. Stop broker

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/notus-scanner/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
