### PR TITLE
Add: gpg verification when loading advisories

### DIFF
--- a/notus/scanner/daemon.py
+++ b/notus/scanner/daemon.py
@@ -38,6 +38,8 @@ from .utils import (
     init_logging,
 )
 
+from .loader.gpg_sha_verifier import gpg_sha256sums, create_verify
+
 from .__version__ import __version__
 
 logger = logging.getLogger(__name__)
@@ -62,8 +64,12 @@ def run_daemon(
     """Initialize the mqtt client, mqtt handler, notus scanner and run
     forever
     """
+
+    sums = gpg_sha256sums((advisories_directory_path / "sha256sums"))
+    verifier = create_verify(sums)
+
     loader = JSONAdvisoriesLoader(
-        advisories_directory_path=advisories_directory_path
+        advisories_directory_path=advisories_directory_path, verify=verifier
     )
     try:
         client = MQTTClient(

--- a/notus/scanner/daemon.py
+++ b/notus/scanner/daemon.py
@@ -65,7 +65,7 @@ def run_daemon(
     forever
     """
 
-    sums = gpg_sha256sums((advisories_directory_path / "sha256sums"))
+    sums = gpg_sha256sums(advisories_directory_path / "sha256sums")
     verifier = create_verify(sums)
 
     loader = JSONAdvisoriesLoader(

--- a/notus/scanner/errors.py
+++ b/notus/scanner/errors.py
@@ -24,5 +24,9 @@ class AdvisoriesLoadingError(NotusScannerError):
     """A problem while loading an Advisory has occurred"""
 
 
+class Sha256SumLoadingError(NotusScannerError):
+    """A problem while loading sha256sums has occurred"""
+
+
 class RpmError(NotusScannerError):
     """A problem while parsing RPM package version information"""

--- a/notus/scanner/loader/gpg_sha_verifier.py
+++ b/notus/scanner/loader/gpg_sha_verifier.py
@@ -6,10 +6,6 @@ from typing import Callable, Dict, Optional
 from gnupg import GPG
 
 
-class GPGError(Exception):
-    """Class for exceptions raised in gpg_sha256sums"""
-
-
 def __default_gpg_home() -> GPG:
     """
     __defaultGpgHome tries to load the variable 'GPG_HOME' or to guess it
@@ -22,7 +18,7 @@ def __default_gpg_home() -> GPG:
 
 def gpg_sha256sums(
     hash_file: Path, gpg: Optional[GPG] = None
-) -> Dict[str, str]:
+) -> Optional[Dict[str, str]]:
     """
     gpg_sha256sums verifies given hash_file with a asc file
 
@@ -34,13 +30,11 @@ def gpg_sha256sums(
     # which may fail on some systems
     if not gpg:
         gpg = __default_gpg_home()
-    if not hash_file.is_file():
-        raise GPGError(f"{hash_file.absolute()} is not a file")
     asc_path = hash_file.parent / f"{hash_file.name}.asc"
     with asc_path.open(mode="rb") as f:
         verified = gpg.verify_file(f, str(hash_file.absolute()))
         if not verified:
-            raise GPGError(f"verification of {hash_file.absolute()} failed")
+            return None
         result = {}
         with hash_file.open() as f:
             for line in f.readlines():

--- a/notus/scanner/loader/gpg_sha_verifier.py
+++ b/notus/scanner/loader/gpg_sha_verifier.py
@@ -6,7 +6,7 @@ from typing import Callable, Dict, Optional
 from gnupg import GPG
 
 
-class GPGException(Exception):
+class GPGError(Exception):
     """Class for exceptions raised in gpg_sha256sums"""
 
 
@@ -35,12 +35,12 @@ def gpg_sha256sums(
     if not gpg:
         gpg = __default_gpg_home()
     if not hash_file.is_file():
-        raise GPGException(f"{hash_file.absolute()} is not a file")
-    asc_path = f"{hash_file}.asc"
+        raise GPGError(f"{hash_file.absolute()} is not a file")
+    asc_path = hash_file.parent / f"{hash_file.name}.asc"
     with asc_path.open(mode="rb") as f:
         verified = gpg.verify_file(f, str(hash_file.absolute()))
         if not verified:
-            raise GPGException(f"verification of {hash_file.absolute()} failed")
+            raise GPGError(f"verification of {hash_file.absolute()} failed")
         result = {}
         with hash_file.open() as f:
             for line in f.readlines():

--- a/notus/scanner/loader/gpg_sha_verifier.py
+++ b/notus/scanner/loader/gpg_sha_verifier.py
@@ -1,0 +1,73 @@
+import hashlib
+import os
+from pathlib import Path
+from typing import Callable, Dict, Optional
+
+import gnupg
+
+
+def __default_gpg_home() -> Optional[Path]:
+    """
+    __defaultGpgHome tries to load the variable 'GPG_HOME' or to guess it
+    """
+    manual = os.getenv("GPG_HOME")
+    if manual:
+        return Path(manual)
+    home = os.getenv("HOME")
+    if home:
+        return Path(home) / ".gnupg"
+    return None
+
+
+def gpg_sha256sums(
+    hash_file: Path, gpg_home: Optional[Path] = __default_gpg_home()
+) -> Dict[str, str]:
+    """
+    gpg_sha256sums verifies given hash_file with a asc file
+
+    This functions assumes that the asc file is in the same directory as the
+    hashfile and has the same name but with the suffix '.asc'
+    """
+    if not gpg_home:
+        raise Exception("no gpg_home set")
+    gpg = gnupg.GPG(gnupghome=f"{gpg_home.absolute()}")
+    if not hash_file.is_file():
+        raise Exception(f"{hash_file.absolute()} is not a file")
+    asc_path = hash_file.parent / f"{hash_file.name}.asc"
+    if not asc_path.is_file():
+        raise Exception(f"{asc_path.absolute()} is not a file")
+    with asc_path.open(mode="rb") as f:
+        verified = gpg.verify_file(f, f"{hash_file.absolute()}")
+        if not verified:
+            raise Exception(f"verification of {hash_file.absolute()} failed")
+        result = {}
+        with hash_file.open() as f:
+            hsum, fname = tuple(f.readline().split("  "))
+            # the second part can contain a newline
+            result[hsum] = fname.strip()
+        return result
+
+
+def create_verify(sha256sums: Dict[str, str]) -> Callable[[Path], bool]:
+    """
+    create_verify is returning a closure based on the sha256sums.
+
+    This allows to load sha256sums and verify there instead of verifying and
+    loading on each verification request.
+    """
+
+    def verify(advisory_path: Path) -> bool:
+        s256h = hashlib.sha256()
+        if not advisory_path.is_file():
+            return False
+
+        with advisory_path.open(mode="rb") as f:
+            for hash_file_bytes in iter(lambda: f.read(1024), b""):
+                s256h.update(hash_file_bytes)
+        hash_sum = s256h.hexdigest()
+        assumed_name = sha256sums.get(hash_sum)
+        if not assumed_name:
+            return False
+        return assumed_name == advisory_path.name
+
+    return verify

--- a/notus/scanner/loader/gpg_sha_verifier.py
+++ b/notus/scanner/loader/gpg_sha_verifier.py
@@ -36,7 +36,7 @@ def gpg_sha256sums(
         gpg = __default_gpg_home()
     if not hash_file.is_file():
         raise GPGException(f"{hash_file.absolute()} is not a file")
-    asc_path = hash_file.parent / f"{hash_file.name}.asc"
+    asc_path = f"{hash_file}.asc"
     with asc_path.open(mode="rb") as f:
         verified = gpg.verify_file(f, str(hash_file.absolute()))
         if not verified:
@@ -44,7 +44,7 @@ def gpg_sha256sums(
         result = {}
         with hash_file.open() as f:
             for line in f.readlines():
-                hsum, fname = tuple(line.split("  "))
+                hsum, fname = line.split("  ")
                 # the second part can contain a newline
                 result[hsum] = fname.strip()
         return result

--- a/notus/scanner/loader/json.py
+++ b/notus/scanner/loader/json.py
@@ -20,6 +20,7 @@ import logging
 
 from json.decoder import JSONDecodeError
 from pathlib import Path
+from typing import Callable
 
 from ..errors import AdvisoriesLoadingError
 from ..models.package import (
@@ -37,8 +38,11 @@ def _get_operating_system_file_name(operating_system: str) -> str:
 
 
 class JSONAdvisoriesLoader(AdvisoriesLoader):
-    def __init__(self, advisories_directory_path: Path):
+    def __init__(
+        self, advisories_directory_path: Path, verify: Callable[[Path], bool]
+    ):
         self._advisories_directory_path = advisories_directory_path
+        self._verify = verify
 
     def load_package_advisories(
         self, operating_system: str
@@ -51,6 +55,11 @@ class JSONAdvisoriesLoader(AdvisoriesLoader):
             raise AdvisoriesLoadingError(
                 f"Could not load advisories from {json_file_path.absolute()}. "
                 "File does not exist."
+            )
+        if not self._verify(json_file_path):
+            raise AdvisoriesLoadingError(
+                f"Could not load advisories from {json_file_path.absolute()}. "
+                "File verification failed."
             )
 
         package_advisories = PackageAdvisories()

--- a/notus/scanner/messages/message.py
+++ b/notus/scanner/messages/message.py
@@ -33,18 +33,18 @@ class Message:
     topic: str = None
     message_type: MessageType = None
     message_id: UUID = None
-    group_id: UUID = None
+    group_id: str = None
     created: datetime = None
 
     def __init__(
         self,
         *,
         message_id: Optional[UUID] = None,
-        group_id: Optional[UUID] = None,
+        group_id: Optional[str] = None,
         created: Optional[datetime] = None,
     ):
         self.message_id = message_id if message_id else uuid4()
-        self.group_id = group_id if group_id else uuid4()
+        self.group_id = group_id if group_id else ""
         self.created = created if created else datetime.utcnow()
 
     @classmethod
@@ -57,7 +57,7 @@ class Message:
             )
         return {
             "message_id": UUID(data.get("message_id")),
-            "group_id": UUID(data.get("group_id")),
+            "group_id": data.get("group_id"),
             "created": datetime.fromtimestamp(
                 float(data.get("created")), timezone.utc
             ),

--- a/notus/scanner/messages/start.py
+++ b/notus/scanner/messages/start.py
@@ -41,7 +41,7 @@ class ScanStartMessage(Message):
         os_release: str,
         package_list: List[str],
         message_id: Optional[UUID] = None,
-        group_id: Optional[UUID] = None,
+        group_id: Optional[str] = None,
         created: Optional[datetime] = None,
     ):
         super().__init__(

--- a/notus/scanner/messages/status.py
+++ b/notus/scanner/messages/status.py
@@ -45,7 +45,7 @@ class ScanStatusMessage(Message):
         host_ip: str,
         status: ScanStatus,
         message_id: Optional[UUID] = None,
-        group_id: Optional[UUID] = None,
+        group_id: Optional[str] = None,
         created: Optional[datetime] = None,
     ):
         super().__init__(

--- a/poetry.lock
+++ b/poetry.lock
@@ -290,6 +290,14 @@ python-versions = ">=3.6"
 diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
+name = "python-gnupg"
+version = "0.4.8"
+description = "A wrapper for the Gnu Privacy Guard (GPG or GnuPG)"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "regex"
 version = "2021.11.10"
 description = "Alternative regular expression module, to replace re."
@@ -581,6 +589,10 @@ pylint = [
 pyparsing = [
     {file = "pyparsing-3.0.6-py3-none-any.whl", hash = "sha256:04ff808a5b90911829c55c4e26f75fa5ca8a2f5f36aa3a51f68e27033341d3e4"},
     {file = "pyparsing-3.0.6.tar.gz", hash = "sha256:d9bdec0013ef1eb5a84ab39a3b3868911598afa494f5faa038647101504e2b81"},
+]
+python-gnupg = [
+    {file = "python-gnupg-0.4.8.tar.gz", hash = "sha256:b64de1ae5cedf872b437201a566fa2c62ce0c95ea2e30177eb53aee1258507d7"},
+    {file = "python_gnupg-0.4.8-py2.py3-none-any.whl", hash = "sha256:93a521501d6c2785d96b190aec7125ba89c1c2fe708b0c98af3fb32b59026ab8"},
 ]
 regex = [
     {file = "regex-2021.11.10-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9345b6f7ee578bad8e475129ed40123d265464c4cfead6c261fd60fc9de00bcf"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ python = "^3.7"
 paho-mqtt = "^1.6"
 psutil = "^5.5"
 sentry-sdk = {version = "^1.5.0", optional = true}
+python-gnupg = "^0.4.8"
 
 [tool.poetry.extras]
 sentry = ["sentry-sdk"]

--- a/tests/loader/test_gpg.py
+++ b/tests/loader/test_gpg.py
@@ -31,12 +31,11 @@ class GpgTest(TestCase):
         omock.__exit__ = Mock()
         pathmock.open.return_value = omock
         emock.readlines.side_effect = [["h  hi\n", "g  gude\n"]]
-        self.assertDictEqual(
-            gpg_sha256sums(pathmock, gmock), {"h": "hi", "g": "gude"}
-        )
-        with self.assertRaises(Exception):
-            gmock.verify_file.side_effect = [False]
-            gpg_sha256sums(pathmock, gmock)
+        success_result = gpg_sha256sums(pathmock, gmock)
+        self.assertIsNotNone(success_result)
+        self.assertDictEqual(success_result, {"h": "hi", "g": "gude"})
+        gmock.verify_file.side_effect = [False]
+        self.assertIsNone(gpg_sha256sums(pathmock, gmock))
 
     @patch("pathlib.Path")
     def test_verify_closure(self, pathmock):

--- a/tests/loader/test_gpg.py
+++ b/tests/loader/test_gpg.py
@@ -1,0 +1,60 @@
+# Copyright (C) 2021 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+from unittest import TestCase
+from unittest.mock import patch, Mock
+from pathlib import Path
+from notus.scanner.loader.gpg_sha_verifier import gpg_sha256sums, create_verify
+
+
+class GpgTest(TestCase):
+    @patch("gnupg.GPG")
+    @patch("pathlib.Path")
+    def test_verifying(self, gmock, pathmock: Path):
+        omock = Mock()
+        emock = Mock()
+        omock.__enter__ = Mock(return_value=emock)
+        omock.__exit__ = Mock()
+        pathmock.open.return_value = omock
+        emock.readlines.side_effect = [["h  hi\n", "g  gude\n"]]
+        self.assertDictEqual(
+            gpg_sha256sums(pathmock, gmock), {"h": "hi", "g": "gude"}
+        )
+        with self.assertRaises(Exception):
+            gmock.verify_file.side_effect = [False]
+            gpg_sha256sums(pathmock, gmock)
+
+    @patch("pathlib.Path")
+    def test_verify_closure(self, pathmock):
+        shas = (
+            "98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4"
+        )
+        vsuccess = create_verify({shas: "hi.txt"})
+        omock = Mock()
+        emock = Mock()
+        omock.__enter__ = Mock(return_value=emock)
+        omock.__exit__ = Mock()
+        pathmock.open.return_value = omock
+        emock.read.side_effect = [bytes("hi\n", "utf-8"), ""]
+        pathmock.name = "hi.txt"
+        self.assertTrue(vsuccess(pathmock))
+        emock.read.side_effect = [bytes("hi\n", "utf-8"), ""]
+        pathmock.name = "false.txt"
+        self.assertFalse(vsuccess(pathmock))
+        emock.read.side_effect = [bytes("hin", "utf-8"), ""]
+        pathmock.name = "hi.txt"
+        self.assertFalse(vsuccess(pathmock))

--- a/tests/loader/test_gpg.py
+++ b/tests/loader/test_gpg.py
@@ -15,8 +15,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-from datetime import timedelta
-import time
 from pathlib import Path
 from unittest import TestCase
 from unittest.mock import Mock, patch
@@ -43,20 +41,18 @@ class GpgTest(TestCase):
         omock.__exit__ = Mock()
         pathmock.open.return_value = omock
         emock.readlines.side_effect = [["h  hi\n"], ["g  gude\n"]]
+        emock.read.side_effect = [b"hi", b"", b"hi", b"", b"ih", b""]
 
         load = reload_sha256sums(
             ReloadConfiguration(
                 hash_file=pathmock,
                 on_verification_failure=on_failure,
-                delta=timedelta(seconds=1),
                 gpg=gmock,
             )
         )
         self.assertDictEqual(load(), {"h": "hi"})
         self.assertDictEqual(load(), {"h": "hi"})
-        time.sleep(1.2)
         self.assertDictEqual(load(), {"g": "gude"})
-        time.sleep(1.2)
         gmock.verify_file.side_effect = [False]
         with self.assertRaises(Exception):
             load()

--- a/tests/loader/test_json.py
+++ b/tests/loader/test_json.py
@@ -27,19 +27,25 @@ _here = Path(__file__).parent
 
 class JSONAdvisoriesLoaderTestCase(TestCase):
     def test_unknown_file(self):
-        loader = JSONAdvisoriesLoader(advisories_directory_path=_here)
+        loader = JSONAdvisoriesLoader(
+            advisories_directory_path=_here, verify=lambda _: True
+        )
 
         with self.assertRaises(AdvisoriesLoadingError):
             loader.load_package_advisories("foo")
 
     def test_empty_file(self):
-        loader = JSONAdvisoriesLoader(advisories_directory_path=_here)
+        loader = JSONAdvisoriesLoader(
+            advisories_directory_path=_here, verify=lambda _: True
+        )
 
         advisories = loader.load_package_advisories("EmptyOS")
         self.assertEqual(len(advisories), 0)
 
     def test_example(self):
-        loader = JSONAdvisoriesLoader(advisories_directory_path=_here)
+        loader = JSONAdvisoriesLoader(
+            advisories_directory_path=_here, verify=lambda _: True
+        )
 
         advisories = loader.load_package_advisories("EulerOS V2.0SP1")
 

--- a/tests/loader/test_json.py
+++ b/tests/loader/test_json.py
@@ -34,6 +34,13 @@ class JSONAdvisoriesLoaderTestCase(TestCase):
         with self.assertRaises(AdvisoriesLoadingError):
             loader.load_package_advisories("foo")
 
+    def test_verification_failure(self):
+        loader = JSONAdvisoriesLoader(
+            advisories_directory_path=_here, verify=lambda _: False
+        )
+        with self.assertRaises(AdvisoriesLoadingError):
+            loader.load_package_advisories("EmptyOS")
+
     def test_empty_file(self):
         loader = JSONAdvisoriesLoader(
             advisories_directory_path=_here, verify=lambda _: True

--- a/tests/messages/test_message.py
+++ b/tests/messages/test_message.py
@@ -28,13 +28,13 @@ class MessageTestCase(TestCase):
         message = Message()
 
         self.assertIsInstance(message.message_id, UUID)
-        self.assertIsInstance(message.group_id, UUID)
+        self.assertIsInstance(message.group_id, str)
         self.assertIsInstance(message.created, datetime)
 
     def test_serialize(self):
         created = datetime.fromtimestamp(1628512774)
         message_id = UUID("63026767-029d-417e-9148-77f4da49f49a")
-        group_id = UUID("866350e8-1492-497e-b12b-c079287d51dd")
+        group_id = "866350e8-1492-497e-b12b-c079287d51dd"
         message = Message(
             message_id=message_id, group_id=group_id, created=created
         )
@@ -64,7 +64,7 @@ class MessageTestCase(TestCase):
             message.message_id, UUID("63026767-029d-417e-9148-77f4da49f49a")
         )
         self.assertEqual(
-            message.group_id, UUID("866350e8-1492-497e-b12b-c079287d51dd")
+            message.group_id, "866350e8-1492-497e-b12b-c079287d51dd"
         )
         self.assertEqual(
             message.created,
@@ -101,7 +101,7 @@ class MessageTestCase(TestCase):
     def test_to_str(self):
         created = datetime.fromtimestamp(1628512774)
         message_id = UUID("63026767-029d-417e-9148-77f4da49f49a")
-        group_id = UUID("866350e8-1492-497e-b12b-c079287d51dd")
+        group_id = "866350e8-1492-497e-b12b-c079287d51dd"
         message = Message(
             message_id=message_id, group_id=group_id, created=created
         )
@@ -129,7 +129,7 @@ class MessageTestCase(TestCase):
             message.message_id, UUID("63026767-029d-417e-9148-77f4da49f49a")
         )
         self.assertEqual(
-            message.group_id, UUID("866350e8-1492-497e-b12b-c079287d51dd")
+            message.group_id, "866350e8-1492-497e-b12b-c079287d51dd"
         )
         self.assertEqual(
             message.created,

--- a/tests/messages/test_result.py
+++ b/tests/messages/test_result.py
@@ -36,7 +36,7 @@ class ResultMessageTestCase(TestCase):
         )
 
         self.assertIsInstance(message.message_id, UUID)
-        self.assertIsInstance(message.group_id, UUID)
+        self.assertIsInstance(message.group_id, str)
         self.assertIsInstance(message.created, datetime)
 
         self.assertEqual(message.message_type, MessageType.RESULT)
@@ -55,7 +55,7 @@ class ResultMessageTestCase(TestCase):
     def test_serialize(self):
         created = datetime.fromtimestamp(1628512774)
         message_id = UUID("63026767-029d-417e-9148-77f4da49f49a")
-        group_id = UUID("866350e8-1492-497e-b12b-c079287d51dd")
+        group_id = "866350e8-1492-497e-b12b-c079287d51dd"
 
         message = ResultMessage(
             created=created,
@@ -108,7 +108,7 @@ class ResultMessageTestCase(TestCase):
             message.message_id, UUID("63026767-029d-417e-9148-77f4da49f49a")
         )
         self.assertEqual(
-            message.group_id, UUID("866350e8-1492-497e-b12b-c079287d51dd")
+            message.group_id, "866350e8-1492-497e-b12b-c079287d51dd"
         )
         self.assertEqual(
             message.created,

--- a/tests/messages/test_start.py
+++ b/tests/messages/test_start.py
@@ -35,7 +35,7 @@ class ScanStartMessageTestCase(TestCase):
         )
 
         self.assertIsInstance(message.message_id, UUID)
-        self.assertIsInstance(message.group_id, UUID)
+        self.assertIsInstance(message.group_id, str)
         self.assertIsInstance(message.created, datetime)
 
         self.assertEqual(message.message_type, MessageType.SCAN_START)
@@ -50,7 +50,7 @@ class ScanStartMessageTestCase(TestCase):
     def test_serialize(self):
         created = datetime.fromtimestamp(1628512774)
         message_id = UUID("63026767-029d-417e-9148-77f4da49f49a")
-        group_id = UUID("866350e8-1492-497e-b12b-c079287d51dd")
+        group_id = "866350e8-1492-497e-b12b-c079287d51dd"
         message = ScanStartMessage(
             message_id=message_id,
             group_id=group_id,
@@ -95,7 +95,7 @@ class ScanStartMessageTestCase(TestCase):
             message.message_id, UUID("63026767-029d-417e-9148-77f4da49f49a")
         )
         self.assertEqual(
-            message.group_id, UUID("866350e8-1492-497e-b12b-c079287d51dd")
+            message.group_id, "866350e8-1492-497e-b12b-c079287d51dd"
         )
         self.assertEqual(
             message.created,

--- a/tests/messages/test_status.py
+++ b/tests/messages/test_status.py
@@ -31,7 +31,7 @@ class ScanStatusMessageTestCase(TestCase):
         )
 
         self.assertIsInstance(message.message_id, UUID)
-        self.assertIsInstance(message.group_id, UUID)
+        self.assertIsInstance(message.group_id, str)
         self.assertIsInstance(message.created, datetime)
 
         self.assertEqual(message.message_type, MessageType.SCAN_STATUS)
@@ -44,7 +44,7 @@ class ScanStatusMessageTestCase(TestCase):
     def test_serialize(self):
         created = datetime.fromtimestamp(1628512774)
         message_id = UUID("63026767-029d-417e-9148-77f4da49f49a")
-        group_id = UUID("866350e8-1492-497e-b12b-c079287d51dd")
+        group_id = "866350e8-1492-497e-b12b-c079287d51dd"
         message = ScanStatusMessage(
             message_id=message_id,
             group_id=group_id,
@@ -83,7 +83,7 @@ class ScanStatusMessageTestCase(TestCase):
             message.message_id, UUID("63026767-029d-417e-9148-77f4da49f49a")
         )
         self.assertEqual(
-            message.group_id, UUID("866350e8-1492-497e-b12b-c079287d51dd")
+            message.group_id, "866350e8-1492-497e-b12b-c079287d51dd"
         )
         self.assertEqual(
             message.created,


### PR DESCRIPTION
This adds a gpg verification when loading advisories; the gpg loading
has the assumptions that:

1. there is a sha256sum file within the advisories dir
2. there is a sha256sums.asc signature within the advisories dir
3. the public key to verify is already known to gpg

It is first loading the sha256sums file and parsing it to a Dict when
successful then it is creating a verify functions based on that dict
which will then be given to the json loader.

With this approach the gpg verifications needs to be done once while the
periodically called start scan is using a cache.
