### PR TITLE
main

### DIFF
--- a/notus/scanner/loader/gpg_sha_verifier.py
+++ b/notus/scanner/loader/gpg_sha_verifier.py
@@ -86,7 +86,11 @@ def gpg_sha256sums(
             for line in f.readlines():
                 hsum, fname = line.split("  ")
                 # the second part can contain a newline
-                result[hsum] = fname.strip()
+                # sometimes the hash sum got generated outside the current dir
+                # and may contain leading paths.
+                # Since we check against the filename we should normalize to
+                # prevent false positives.
+                result[hsum] = fname.split("/")[-1].strip()
         return result
 
 

--- a/notus/scanner/loader/gpg_sha_verifier.py
+++ b/notus/scanner/loader/gpg_sha_verifier.py
@@ -1,3 +1,4 @@
+from enum import Enum
 import hashlib
 import os
 from pathlib import Path
@@ -89,9 +90,16 @@ def gpg_sha256sums(
         return result
 
 
+class VerificationResult(Enum):
+    INVALID_FILE = 0
+    INVALID_HASH = 1
+    INVALID_NAME = 2
+    SUCCESS = 3
+
+
 def create_verify(
     sha256sums: Callable[[], Dict[str, str]]
-) -> Callable[[Path], bool]:
+) -> Callable[[Path], VerificationResult]:
     """
     create_verify is returning a closure based on the sha256sums.
 
@@ -99,10 +107,10 @@ def create_verify(
     loading on each verification request.
     """
 
-    def verify(advisory_path: Path) -> bool:
+    def verify(advisory_path: Path) -> VerificationResult:
         s256h = hashlib.sha256()
         if not advisory_path.is_file():
-            return False
+            return VerificationResult.INVALID_FILE
 
         with advisory_path.open(mode="rb") as f:
             for hash_file_bytes in iter(lambda: f.read(1024), b""):
@@ -111,7 +119,11 @@ def create_verify(
 
         assumed_name = sha256sums().get(hash_sum)
         if not assumed_name:
-            return False
-        return assumed_name == advisory_path.name
+            return VerificationResult.INVALID_HASH
+        return (
+            VerificationResult.SUCCESS
+            if assumed_name == advisory_path.name
+            else VerificationResult.INVALID_NAME
+        )
 
     return verify

--- a/tests/loader/test_gpg.py
+++ b/tests/loader/test_gpg.py
@@ -22,6 +22,7 @@ from typing import Dict, Optional
 
 from notus.scanner.loader.gpg_sha_verifier import (
     ReloadConfiguration,
+    VerificationResult,
     create_verify,
     gpg_sha256sums,
     reload_sha256sums,
@@ -85,10 +86,10 @@ class GpgTest(TestCase):
         pathmock.open.return_value = omock
         emock.read.side_effect = [bytes("hi\n", "utf-8"), ""]
         pathmock.name = "hi.txt"
-        self.assertTrue(vsuccess(pathmock))
+        self.assertEqual(vsuccess(pathmock), VerificationResult.SUCCESS)
         emock.read.side_effect = [bytes("hi\n", "utf-8"), ""]
         pathmock.name = "false.txt"
-        self.assertFalse(vsuccess(pathmock))
+        self.assertEqual(vsuccess(pathmock), VerificationResult.INVALID_NAME)
         emock.read.side_effect = [bytes("hin", "utf-8"), ""]
         pathmock.name = "hi.txt"
-        self.assertFalse(vsuccess(pathmock))
+        self.assertEqual(vsuccess(pathmock), VerificationResult.INVALID_HASH)

--- a/tests/loader/test_json.py
+++ b/tests/loader/test_json.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from unittest import TestCase
 
 from notus.scanner.errors import AdvisoriesLoadingError
+from notus.scanner.loader.gpg_sha_verifier import VerificationResult
 from notus.scanner.loader.json import JSONAdvisoriesLoader
 from notus.scanner.models.packages.rpm import RPMPackage
 
@@ -28,22 +29,24 @@ _here = Path(__file__).parent
 class JSONAdvisoriesLoaderTestCase(TestCase):
     def test_unknown_file(self):
         loader = JSONAdvisoriesLoader(
-            advisories_directory_path=_here, verify=lambda _: True
+            advisories_directory_path=_here,
+            verify=lambda _: VerificationResult.SUCCESS,
         )
 
-        with self.assertRaises(AdvisoriesLoadingError):
-            loader.load_package_advisories("foo")
+        self.assertIsNone(loader.load_package_advisories("foo"))
 
     def test_verification_failure(self):
         loader = JSONAdvisoriesLoader(
-            advisories_directory_path=_here, verify=lambda _: False
+            advisories_directory_path=_here,
+            verify=lambda _: VerificationResult.INVALID_HASH,
         )
         with self.assertRaises(AdvisoriesLoadingError):
             loader.load_package_advisories("EmptyOS")
 
     def test_empty_file(self):
         loader = JSONAdvisoriesLoader(
-            advisories_directory_path=_here, verify=lambda _: True
+            advisories_directory_path=_here,
+            verify=lambda _: VerificationResult.SUCCESS,
         )
 
         advisories = loader.load_package_advisories("EmptyOS")
@@ -51,7 +54,8 @@ class JSONAdvisoriesLoaderTestCase(TestCase):
 
     def test_example(self):
         loader = JSONAdvisoriesLoader(
-            advisories_directory_path=_here, verify=lambda _: True
+            advisories_directory_path=_here,
+            verify=lambda _: VerificationResult.SUCCESS,
         )
 
         advisories = loader.load_package_advisories("EulerOS V2.0SP1")


### PR DESCRIPTION
- Refactor add more detail when the file verification fails on load
- Add filename normalization before check

This commit removes path indicator on unix like machines to prevent
false positives when the hashsum contains a path rather than a filename