### PR TITLE
Fix RPM package comparision with different architectures

### DIFF
--- a/notus/scanner/models/packages/deb.py
+++ b/notus/scanner/models/packages/deb.py
@@ -23,7 +23,7 @@ from typing import Tuple
 from dataclasses import dataclass
 from packaging.version import parse
 
-from .package import Package
+from .package import Package, PackageComparision
 
 _deb_compile = re.compile(r"(.*)-(?:(\d*):)?(.*)-(.*)")
 _deb_compile_wo_revision = re.compile(r"(.*)-(?:(\d*):)?(.*)")
@@ -47,10 +47,18 @@ class DEBPackage(Package):
 
     __hash__ = Package.__hash__
 
-    def _compare(self, other: Package) -> int:
-        v1 = parse(self.full_version)
-        v2 = parse(other.full_version)
-        return v1 > v2
+    def _compare(self, other: Package) -> PackageComparision:
+        a_version = parse(self.full_version)
+        b_version = parse(other.full_version)
+
+        if a_version == b_version:
+            return PackageComparision.EQUAL
+
+        return (
+            PackageComparision.A_NEWER
+            if a_version > b_version
+            else PackageComparision.B_NEWER
+        )
 
     @staticmethod
     def from_full_name(full_name: str):

--- a/notus/scanner/models/packages/package.py
+++ b/notus/scanner/models/packages/package.py
@@ -26,14 +26,6 @@ from ...errors import PackageError
 
 logger = logging.getLogger(__name__)
 
-# Return values:
-#   a_newer: a is newer than b, return 1
-#   _B_NEWER: b is newer than a, return -1
-#   _A_EQ_B: a and b are equal, return 0
-A_NEWER = 1
-B_NEWER = -1
-A_EQ_B = 0
-
 
 class PackageType(Enum):
     RPM = "rpm"
@@ -45,6 +37,14 @@ class PackageType(Enum):
             return PackageType[guess.upper()]
         except KeyError:
             return None
+
+
+class PackageComparision(Enum):
+    EQUAL = 0  # a and b are equal
+    A_NEWER = 1  # a is newer than b
+    B_NEWER = 2  # b is newer than a
+    # a and b are not compareable. e.g. different architectures
+    NOT_COMPARABLE = 3
 
 
 class Architecture(Enum):
@@ -81,7 +81,7 @@ class Package:
         if not isinstance(other, type(self)):
             raise PackageError(f"Can't compare {self!r} to {other!r}.")
 
-        return self._compare(other) > 0
+        return self._compare(other) == PackageComparision.A_NEWER
 
     def __hash__(self) -> int:
         # allow to hash the package
@@ -89,7 +89,7 @@ class Package:
         return hash(self.full_name)
 
     @abstractmethod
-    def _compare(self, other: Any) -> bool:
+    def _compare(self, other: Any) -> PackageComparision:
         raise NotImplementedError()
 
     @staticmethod

--- a/notus/scanner/models/packages/rpm.py
+++ b/notus/scanner/models/packages/rpm.py
@@ -33,6 +33,9 @@ class RPMPackage(Package):
     __hash__ = Package.__hash__
 
     def _compare(self, other: "RPMPackage") -> PackageComparision:
+        if self.arch != other.arch:
+            return PackageComparision.NOT_COMPARABLE
+
         if self.full_version == other.full_version:
             return PackageComparision.EQUAL
 

--- a/notus/scanner/models/packages/rpm.py
+++ b/notus/scanner/models/packages/rpm.py
@@ -7,7 +7,11 @@ import re
 from dataclasses import dataclass
 from packaging.version import parse
 
-from .package import Package, Architecture, A_NEWER, B_NEWER, A_EQ_B
+from .package import (
+    Package,
+    Architecture,
+    PackageComparision,
+)
 
 _rpm_re = re.compile(r"(\S+)-(?:(\d*):)?(.*)-(~?\w+[\w.]*)")
 
@@ -28,17 +32,25 @@ class RPMPackage(Package):
 
     __hash__ = Package.__hash__
 
-    def _compare(self, other: Package) -> int:
+    def _compare(self, other: "RPMPackage") -> PackageComparision:
         if self.full_version == other.full_version:
-            return A_EQ_B
+            return PackageComparision.EQUAL
 
         a_ver = parse(self.version)
         b_ver = parse(other.version)
         if a_ver != b_ver:
-            return A_NEWER if a_ver > b_ver else B_NEWER
+            return (
+                PackageComparision.A_NEWER
+                if a_ver > b_ver
+                else PackageComparision.B_NEWER
+            )
         a_rel = parse(self.release)
         b_rel = parse(other.release)
-        return A_NEWER if a_rel > b_rel else B_NEWER
+        return (
+            PackageComparision.A_NEWER
+            if a_rel > b_rel
+            else PackageComparision.B_NEWER
+        )
 
     @staticmethod
     def from_full_name(full_name: str):

--- a/tests/models/packages/test_rpm.py
+++ b/tests/models/packages/test_rpm.py
@@ -71,8 +71,28 @@ class RPMPackageTestCase(TestCase):
             full_name="foo-bar-1.2.3-4.aarch64",
             full_version="1.2.3-4.aarch64",
         )
+        package3 = RPMPackage(
+            name="foo-bar",
+            version="1.2.4",
+            release="4",
+            arch=Architecture.AARCH64,
+            full_name="foo-bar-1.2.4-4.aarch64",
+            full_version="1.2.4-4.aarch64",
+        )
+        package4 = RPMPackage(
+            name="foo-bar",
+            version="1.2.3",
+            release="5",
+            arch=Architecture.AARCH64,
+            full_name="foo-bar-1.2.3-5.aarch64",
+            full_version="1.2.3-5.aarch64",
+        )
         self.assertFalse(package2 > package1)
         self.assertFalse(package1 > package2)
+        self.assertFalse(package3 > package1)
+        self.assertFalse(package1 > package3)
+        self.assertFalse(package4 > package1)
+        self.assertFalse(package1 > package4)
 
     def test_compare_less(self):
         """packages should be comparable"""


### PR DESCRIPTION
**What**:

Ensure that the architecture is considered when comparing RPM packages.

SC-478

**Why**:

Packages with different architectures are not comparable.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/notus-scanner/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
