### PR TITLE
Fix: set uuid for group_id

### DIFF
--- a/notus/scanner/messages/message.py
+++ b/notus/scanner/messages/message.py
@@ -40,11 +40,11 @@ class Message:
         self,
         *,
         message_id: Optional[UUID] = None,
-        group_id: Optional[str] = None,
+        group_id: Optional[UUID] = None,
         created: Optional[datetime] = None,
     ):
         self.message_id = message_id if message_id else uuid4()
-        self.group_id = group_id if group_id else ""
+        self.group_id = group_id if group_id else uuid4()
         self.created = created if created else datetime.utcnow()
 
     @classmethod
@@ -57,7 +57,7 @@ class Message:
             )
         return {
             "message_id": UUID(data.get("message_id")),
-            "group_id": data.get("group_id"),
+            "group_id": UUID(data.get("group_id")),
             "created": datetime.fromtimestamp(
                 float(data.get("created")), timezone.utc
             ),

--- a/tests/messages/test_message.py
+++ b/tests/messages/test_message.py
@@ -28,13 +28,13 @@ class MessageTestCase(TestCase):
         message = Message()
 
         self.assertIsInstance(message.message_id, UUID)
-        self.assertIsInstance(message.group_id, str)
+        self.assertIsInstance(message.group_id, UUID)
         self.assertIsInstance(message.created, datetime)
 
     def test_serialize(self):
         created = datetime.fromtimestamp(1628512774)
         message_id = UUID("63026767-029d-417e-9148-77f4da49f49a")
-        group_id = "866350e8-1492-497e-b12b-c079287d51dd"
+        group_id = UUID("866350e8-1492-497e-b12b-c079287d51dd")
         message = Message(
             message_id=message_id, group_id=group_id, created=created
         )
@@ -64,7 +64,7 @@ class MessageTestCase(TestCase):
             message.message_id, UUID("63026767-029d-417e-9148-77f4da49f49a")
         )
         self.assertEqual(
-            message.group_id, "866350e8-1492-497e-b12b-c079287d51dd"
+            message.group_id, UUID("866350e8-1492-497e-b12b-c079287d51dd")
         )
         self.assertEqual(
             message.created,
@@ -101,7 +101,7 @@ class MessageTestCase(TestCase):
     def test_to_str(self):
         created = datetime.fromtimestamp(1628512774)
         message_id = UUID("63026767-029d-417e-9148-77f4da49f49a")
-        group_id = "866350e8-1492-497e-b12b-c079287d51dd"
+        group_id = UUID("866350e8-1492-497e-b12b-c079287d51dd")
         message = Message(
             message_id=message_id, group_id=group_id, created=created
         )
@@ -129,7 +129,7 @@ class MessageTestCase(TestCase):
             message.message_id, UUID("63026767-029d-417e-9148-77f4da49f49a")
         )
         self.assertEqual(
-            message.group_id, "866350e8-1492-497e-b12b-c079287d51dd"
+            message.group_id, UUID("866350e8-1492-497e-b12b-c079287d51dd")
         )
         self.assertEqual(
             message.created,

--- a/tests/messages/test_result.py
+++ b/tests/messages/test_result.py
@@ -36,7 +36,7 @@ class ResultMessageTestCase(TestCase):
         )
 
         self.assertIsInstance(message.message_id, UUID)
-        self.assertIsInstance(message.group_id, str)
+        self.assertIsInstance(message.group_id, UUID)
         self.assertIsInstance(message.created, datetime)
 
         self.assertEqual(message.message_type, MessageType.RESULT)
@@ -108,7 +108,7 @@ class ResultMessageTestCase(TestCase):
             message.message_id, UUID("63026767-029d-417e-9148-77f4da49f49a")
         )
         self.assertEqual(
-            message.group_id, "866350e8-1492-497e-b12b-c079287d51dd"
+            message.group_id, UUID("866350e8-1492-497e-b12b-c079287d51dd")
         )
         self.assertEqual(
             message.created,

--- a/tests/messages/test_start.py
+++ b/tests/messages/test_start.py
@@ -35,7 +35,7 @@ class ScanStartMessageTestCase(TestCase):
         )
 
         self.assertIsInstance(message.message_id, UUID)
-        self.assertIsInstance(message.group_id, str)
+        self.assertIsInstance(message.group_id, UUID)
         self.assertIsInstance(message.created, datetime)
 
         self.assertEqual(message.message_type, MessageType.SCAN_START)
@@ -95,7 +95,7 @@ class ScanStartMessageTestCase(TestCase):
             message.message_id, UUID("63026767-029d-417e-9148-77f4da49f49a")
         )
         self.assertEqual(
-            message.group_id, "866350e8-1492-497e-b12b-c079287d51dd"
+            message.group_id, UUID("866350e8-1492-497e-b12b-c079287d51dd")
         )
         self.assertEqual(
             message.created,

--- a/tests/messages/test_status.py
+++ b/tests/messages/test_status.py
@@ -31,7 +31,7 @@ class ScanStatusMessageTestCase(TestCase):
         )
 
         self.assertIsInstance(message.message_id, UUID)
-        self.assertIsInstance(message.group_id, str)
+        self.assertIsInstance(message.group_id, UUID)
         self.assertIsInstance(message.created, datetime)
 
         self.assertEqual(message.message_type, MessageType.SCAN_STATUS)
@@ -44,7 +44,7 @@ class ScanStatusMessageTestCase(TestCase):
     def test_serialize(self):
         created = datetime.fromtimestamp(1628512774)
         message_id = UUID("63026767-029d-417e-9148-77f4da49f49a")
-        group_id = "866350e8-1492-497e-b12b-c079287d51dd"
+        group_id = UUID("866350e8-1492-497e-b12b-c079287d51dd")
         message = ScanStatusMessage(
             message_id=message_id,
             group_id=group_id,
@@ -83,7 +83,7 @@ class ScanStatusMessageTestCase(TestCase):
             message.message_id, UUID("63026767-029d-417e-9148-77f4da49f49a")
         )
         self.assertEqual(
-            message.group_id, "866350e8-1492-497e-b12b-c079287d51dd"
+            message.group_id, UUID("866350e8-1492-497e-b12b-c079287d51dd")
         )
         self.assertEqual(
             message.created,


### PR DESCRIPTION
**What**:
Fill group_id with an uuid, when none is given.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
ospd-openvas expects an uuid in the group_id field. In case none was given ospd-openvas was unable to parse the message.

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/notus-scanner/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
