### PR TITLE
Publish notus-scanner container on dockerhub

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -6,9 +6,6 @@ on:
     tags: ["v*"]
   workflow_dispatch:
 
-env:
-  REGISTRY: ghcr.io
-
 jobs:
   images:
     name: Build images
@@ -17,14 +14,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Find reference version
-        uses: greenbone/actions/reference-version@v1
+      - name: Gather container image tags
+        id: container
+        uses: greenbone/actions/container-image-tags@v1
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Install poetry and dependencies
         uses: greenbone/actions/poetry@v1
         with:
@@ -36,5 +33,5 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ env.REGISTRY }}/${{ github.repository }}:${{ env.VERSION }}
+          tags: ${{ steps.container.outputs.image-tags }}
           file: .docker/notus-scanner.Dockerfile

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -35,3 +35,6 @@ jobs:
           push: true
           tags: ${{ steps.container.outputs.image-tags }}
           file: .docker/notus-scanner.Dockerfile
+          labels: |
+            org.opencontainers.image.vendor=Greenbone
+            org.opencontainers.image.revision=${{ github.sha }}


### PR DESCRIPTION
**What**:

notus-scanner is a public project therefore the container images should
also be published on dockerhub. Additionally use our
container-image-tags action to use a consistent container naming.

**Why**:

All container images of public repos should be published at hub.docker.com.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/notus-scanner/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
