### PR TITLE
Refactor: change topic from scanner/results to scanner/scan/info

### DIFF
--- a/notus/scanner/messages/result.py
+++ b/notus/scanner/messages/result.py
@@ -29,7 +29,7 @@ class ResultType(Enum):
 
 class ResultMessage(Message):
     message_type: MessageType = MessageType.RESULT
-    topic = "scanner/results"
+    topic = "scanner/scan/info"
 
     def __init__(
         self,

--- a/tests/messages/test_result.py
+++ b/tests/messages/test_result.py
@@ -40,7 +40,7 @@ class ResultMessageTestCase(TestCase):
         self.assertIsInstance(message.created, datetime)
 
         self.assertEqual(message.message_type, MessageType.RESULT)
-        self.assertEqual(message.topic, "scanner/results")
+        self.assertEqual(message.topic, "scanner/scan/info")
 
         self.assertEqual(message.scan_id, "scan_1")
         self.assertEqual(message.host_ip, "1.1.1.1")


### PR DESCRIPTION
To make it easier to find notus results adjust the topic to
scanner/scan/info. This makes it easier to sport notus messages in a
different scan management environment than ospd.
