### PR TITLE
Add: error handling, prevent notus from stopping

### DIFF
--- a/notus/scanner/errors.py
+++ b/notus/scanner/errors.py
@@ -32,5 +32,9 @@ class PackageError(NotusScannerError):
     """Base Class for errors raised in package handling"""
 
 
+class MessageParsingError(NotusScannerError):
+    """A problem while parsing an incoming message"""
+
+
 class ConfigFileError(NotusScannerError):
     """ "A problem while parsing the config file has occurred"""

--- a/notus/scanner/messages/message.py
+++ b/notus/scanner/messages/message.py
@@ -55,12 +55,26 @@ class Message:
                 f"Invalid message type {message_type} for {cls.__name__}. "
                 f"Must be {cls.message_type}.",
             )
-        return {
-            "message_id": UUID(data.get("message_id")),
-            "group_id": UUID(data.get("group_id")),
-            "created": datetime.fromtimestamp(
+
+        try:
+            message_id = UUID(data.get("message_id"))
+        except (TypeError, ValueError) as e:
+            raise e.__class__(f"error while parsing 'message_id', {e}")
+        try:
+            group_id = UUID(data.get("group_id"))
+        except (TypeError, ValueError) as e:
+            raise e.__class__(f"error while parsing 'group_id', {e}")
+        try:
+            created = datetime.fromtimestamp(
                 float(data.get("created")), timezone.utc
-            ),
+            )
+        except (TypeError, ValueError) as e:
+            raise e.__class__(f"error while parsing 'created', {e}")
+
+        return {
+            "message_id": message_id,
+            "group_id": group_id,
+            "created": created,
         }
 
     def serialize(self) -> Dict[str, Union[int, str]]:

--- a/notus/scanner/messages/result.py
+++ b/notus/scanner/messages/result.py
@@ -20,6 +20,8 @@ from enum import Enum
 from typing import Dict, Union, Any, Optional
 from uuid import UUID
 
+from notus.scanner.errors import MessageParsingError
+
 from .message import Message, MessageType
 
 
@@ -77,16 +79,21 @@ class ResultMessage(Message):
     @classmethod
     def _parse(cls, data: Dict[str, Union[int, str]]) -> Dict[str, Any]:
         kwargs = super()._parse(data)
-        kwargs.update(
-            {
-                "scan_id": data.get("scan_id"),
-                "host_ip": data.get("host_ip"),
-                "host_name": data.get("host_name"),
-                "oid": data.get("oid"),
-                "value": data.get("value"),
-                "port": data.get("port"),
-                "uri": data.get("uri"),
-                "result_type": ResultType(data.get("result_type")),
-            }
-        )
+        try:
+            kwargs.update(
+                {
+                    "scan_id": data.get("scan_id"),
+                    "host_ip": data.get("host_ip"),
+                    "host_name": data.get("host_name"),
+                    "oid": data.get("oid"),
+                    "value": data.get("value"),
+                    "port": data.get("port"),
+                    "uri": data.get("uri"),
+                    "result_type": ResultType(data.get("result_type")),
+                }
+            )
+        except ValueError as e:
+            raise MessageParsingError(
+                f"error while parsing 'result_type', {e}"
+            ) from e
         return kwargs

--- a/notus/scanner/messages/start.py
+++ b/notus/scanner/messages/start.py
@@ -19,6 +19,8 @@ from datetime import datetime
 from typing import Dict, Union, Any, List, Optional
 from uuid import UUID
 
+from notus.scanner.errors import MessageParsingError
+
 from .message import Message, MessageType
 
 
@@ -72,7 +74,7 @@ class ScanStartMessage(Message):
 
         package_list = data.get("package_list")
         if not isinstance(package_list, list):
-            raise ValueError("package_list must contain a list")
+            raise MessageParsingError("package_list must contain a list")
 
         kwargs.update(
             {

--- a/notus/scanner/messaging/mqtt.py
+++ b/notus/scanner/messaging/mqtt.py
@@ -23,6 +23,8 @@ from typing import Callable, Type
 
 import paho.mqtt.client as mqtt
 
+from notus.scanner.errors import MessageParsingError
+
 from ..messages.message import Message
 
 from .publisher import Publisher
@@ -118,7 +120,7 @@ class MQTTSubscriber(Subscriber):
             )
             logger.debug("Got: %s", msg.payload)
             return
-        except (ValueError, TypeError) as e:
+        except MessageParsingError as e:
             logger.error(
                 "Could not parse message for topic %s. Error was %s",
                 msg.topic,

--- a/notus/scanner/messaging/mqtt.py
+++ b/notus/scanner/messaging/mqtt.py
@@ -118,7 +118,7 @@ class MQTTSubscriber(Subscriber):
             )
             logger.debug("Got: %s", msg.payload)
             return
-        except ValueError as e:
+        except (ValueError, TypeError) as e:
             logger.error(
                 "Could not parse message for topic %s. Error was %s",
                 msg.topic,
@@ -151,9 +151,10 @@ class MQTTDaemon:
             logger.error("Failed to connect to broker. Reason code %s", rc)
 
     @staticmethod
-    def on_disconnect(client, _userdata, rc, _properties):
+    def on_disconnect(
+        client, _userdata, rc, _properties  # pylint: disable=unused-argument
+    ):
         logger.info("Disconnected from broker. Reason code %s", rc)
-        client.loop_stop()
 
     def run(self):
         self._client.loop_forever()

--- a/notus/scanner/models/packages/package.py
+++ b/notus/scanner/models/packages/package.py
@@ -31,13 +31,6 @@ class PackageType(Enum):
     RPM = "rpm"
     DEB = "deb"
 
-    @staticmethod
-    def from_string(guess: str):
-        try:
-            return PackageType[guess.upper()]
-        except KeyError:
-            return None
-
 
 class PackageComparision(Enum):
     EQUAL = 0  # a and b are equal

--- a/tests/loader/invalid_package.notus
+++ b/tests/loader/invalid_package.notus
@@ -1,0 +1,42 @@
+{
+    "version": "1.0",
+    "package_type": "foo",
+    "product_name": "Huawei EulerOS v2.0 SP1",
+    "advisories": [
+        {
+            "oid": "1.3.6.1.4.1.25623.1.1.2.2016.1001",
+            "fixed_packages": [
+                {
+                    "full_name": "postgresql-9.2.15-1.x86_64"
+                },
+                {
+                    "full_name": "postgresql-contrib-9.2.15-1.x86_64"
+                },
+                {
+                    "full_name": "postgresql-devel-9.2.15-1.x86_64"
+                },
+                {
+                    "full_name": "postgresql-docs-9.2.15-1.x86_64"
+                },
+                {
+                    "full_name": "postgresql-libs-9.2.15-1.x86_64"
+                },
+                {
+                    "full_name": "postgresql-plperl-9.2.15-1.x86_64"
+                },
+                {
+                    "full_name": "postgresql-plpython-9.2.15-1.x86_64"
+                },
+                {
+                    "full_name": "postgresql-pltcl-9.2.15-1.x86_64"
+                },
+                {
+                    "full_name": "postgresql-server-9.2.15-1.x86_64"
+                },
+                {
+                    "full_name": "postgresql-test-9.2.15-1.x86_64"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/loader/test_json.py
+++ b/tests/loader/test_json.py
@@ -92,3 +92,13 @@ class JSONAdvisoriesLoaderTestCase(TestCase):
         advisory = package_advisory1.advisory
 
         self.assertEqual(advisory.oid, "1.3.6.1.4.1.25623.1.1.2.2016.1008")
+
+    def test_invalid_package_type(self):
+        loader = JSONAdvisoriesLoader(
+            advisories_directory_path=_here,
+            verify=lambda _: VerificationResult.SUCCESS,
+        )
+
+        advisory = loader.load_package_advisories("invalid_package")
+
+        self.assertIsNone(advisory)

--- a/tests/messages/test_message.py
+++ b/tests/messages/test_message.py
@@ -19,6 +19,7 @@ from datetime import datetime, timezone
 from uuid import UUID
 
 from unittest import TestCase
+from notus.scanner.errors import MessageParsingError
 
 from notus.scanner.messages.message import Message, MessageType
 
@@ -81,7 +82,9 @@ class MessageTestCase(TestCase):
         }
 
         with self.assertRaisesRegex(
-            ValueError, "None is not a valid MessageType"
+            MessageParsingError,
+            "error while parsing 'message_type', None is not a valid"
+            " MessageType",
         ):
             Message.deserialize(data)
 
@@ -94,7 +97,9 @@ class MessageTestCase(TestCase):
         }
 
         with self.assertRaisesRegex(
-            ValueError, "'foo' is not a valid MessageType"
+            MessageParsingError,
+            "error while parsing 'message_type', 'foo' is not a valid"
+            " MessageType",
         ):
             Message.deserialize(data)
 
@@ -136,4 +141,84 @@ class MessageTestCase(TestCase):
             datetime.fromtimestamp(1628512774.0, tz=timezone.utc),
         )
 
+        Message.message_type = None
+
+    def test_load_message_id_unvalid(self):
+        payload = (
+            '{"message_id": "foo", '
+            '"message_type": "scan.start", '
+            '"group_id": "866350e8-1492-497e-b12b-c079287d51dd", '
+            '"created": 1628512774.0}'
+        )
+        Message.message_type = MessageType.SCAN_START
+        with self.assertRaises(MessageParsingError):
+            Message.load(payload)
+        Message.message_type = None
+
+    def test_load_message_id_missing(self):
+        payload = (
+            '{"message_type": "scan.start", '
+            '"group_id": "866350e8-1492-497e-b12b-c079287d51dd", '
+            '"created": 1628512774.0}'
+        )
+        Message.message_type = MessageType.SCAN_START
+        with self.assertRaises(MessageParsingError):
+            Message.load(payload)
+        Message.message_type = None
+
+    def test_load_group_id_unvalid(self):
+        payload = (
+            '{"message_id": "63026767-029d-417e-9148-77f4da49f49a", '
+            '"message_type": "scan.start", '
+            '"group_id": "bar", '
+            '"created": 1628512774.0}'
+        )
+        Message.message_type = MessageType.SCAN_START
+        with self.assertRaises(MessageParsingError):
+            Message.load(payload)
+        Message.message_type = None
+
+    def test_load_group_id_missing(self):
+        payload = (
+            '{"message_id": "63026767-029d-417e-9148-77f4da49f49a", '
+            '"message_type": "scan.start", '
+            '"created": 1628512774.0}'
+        )
+        Message.message_type = MessageType.SCAN_START
+        with self.assertRaises(MessageParsingError):
+            Message.load(payload)
+        Message.message_type = None
+
+    def test_load_message_type_missing(self):
+        payload = (
+            '{"message_id": "63026767-029d-417e-9148-77f4da49f49a", '
+            '"group_id": "866350e8-1492-497e-b12b-c079287d51dd", '
+            '"created": 1628512774.0}'
+        )
+        Message.message_type = MessageType.SCAN_START
+        with self.assertRaises(MessageParsingError):
+            Message.load(payload)
+        Message.message_type = None
+
+    def test_load_created_unvalid(self):
+        payload = (
+            '{"message_id": "63026767-029d-417e-9148-77f4da49f49a", '
+            '"message_type": "scan.start", '
+            '"group_id": "866350e8-1492-497e-b12b-c079287d51dd", '
+            '"created": "a"}'
+        )
+        Message.message_type = MessageType.SCAN_START
+        with self.assertRaises(MessageParsingError):
+            Message.load(payload)
+        Message.message_type = None
+
+    def test_load_created_missing(self):
+        payload = (
+            '{"message_id": "63026767-029d-417e-9148-77f4da49f49a", '
+            '"message_type": "scan.start", '
+            '"group_id": "866350e8-1492-497e-b12b-c079287d51dd"}'
+        )
+        Message.message_type = MessageType.SCAN_START
+        with self.assertRaises(MessageParsingError):
+            Message.load(payload)
         Message.message_type = None

--- a/tests/messages/test_result.py
+++ b/tests/messages/test_result.py
@@ -19,6 +19,7 @@ from datetime import datetime, timezone
 from uuid import UUID
 
 from unittest import TestCase
+from notus.scanner.errors import MessageParsingError
 
 from notus.scanner.messages.message import MessageType
 from notus.scanner.messages.result import ResultMessage, ResultType
@@ -141,7 +142,7 @@ class ResultMessageTestCase(TestCase):
             "result_type": "ALARM",
         }
         with self.assertRaisesRegex(
-            ValueError,
+            MessageParsingError,
             "Invalid message type MessageType.SCAN_STATUS for "
             "ResultMessage. Must be MessageType.RESULT.",
         ):
@@ -164,6 +165,8 @@ class ResultMessageTestCase(TestCase):
         }
 
         with self.assertRaisesRegex(
-            ValueError, "'foo' is not a valid ResultType"
+            MessageParsingError,
+            "error while parsing 'result_type', 'foo' is not a valid"
+            " ResultType",
         ):
             ResultMessage.deserialize(data)

--- a/tests/messages/test_start.py
+++ b/tests/messages/test_start.py
@@ -19,6 +19,7 @@ from datetime import datetime, timezone
 from uuid import UUID
 
 from unittest import TestCase
+from notus.scanner.errors import MessageParsingError
 
 from notus.scanner.messages.message import MessageType
 from notus.scanner.messages.start import ScanStartMessage
@@ -125,9 +126,9 @@ class ScanStartMessageTestCase(TestCase):
         }
 
         with self.assertRaisesRegex(
-            ValueError,
-            "Invalid message type MessageType.SCAN_STATUS for "
-            "ScanStartMessage. Must be MessageType.SCAN_START.",
+            MessageParsingError,
+            "Invalid message type MessageType.SCAN_STATUS for ScanStartMessage."
+            " Must be MessageType.SCAN_START.",
         ):
             ScanStartMessage.deserialize(data)
 
@@ -145,6 +146,6 @@ class ScanStartMessageTestCase(TestCase):
         }
 
         with self.assertRaisesRegex(
-            ValueError, "package_list must contain a list"
+            MessageParsingError, "package_list must contain a list"
         ):
             ScanStartMessage.deserialize(data)

--- a/tests/messages/test_status.py
+++ b/tests/messages/test_status.py
@@ -19,6 +19,7 @@ from datetime import datetime, timezone
 from uuid import UUID
 
 from unittest import TestCase
+from notus.scanner.errors import MessageParsingError
 
 from notus.scanner.messages.message import MessageType
 from notus.scanner.messages.status import ScanStatus, ScanStatusMessage
@@ -124,7 +125,7 @@ class ScanStatusMessageTestCase(TestCase):
         }
 
         with self.assertRaisesRegex(
-            ValueError,
+            MessageParsingError,
             "Invalid message type MessageType.SCAN_START for ScanStatusMessage."
             " Must be MessageType.SCAN_STATUS.",
         ):

--- a/tests/messaging/test_mqtt.py
+++ b/tests/messaging/test_mqtt.py
@@ -72,15 +72,7 @@ class MQTTSubscriberTestCase(TestCase):
 
         subscriber = MQTTSubscriber(client)
 
-        message = ScanStartMessage(
-            scan_id="scan_1",
-            host_ip="1.1.1.1",
-            host_name="foo",
-            os_release="BarOS 1.0",
-            package_list=["foo-1.2.3-1.x86_64"],
-        )
-
-        subscriber.subscribe(message, callback)
+        subscriber.subscribe(ScanStartMessage, callback)
 
         client.subscribe.assert_called_with("scanner/package/cmd/notus", qos=1)
 


### PR DESCRIPTION
**What**:
This PR improves the error handling to prevent it from crashing during scans.
SC-366

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
To improve the stability of the notus-scanner

<!-- Why are these changes necessary? -->

**How**:
Using a MQTT tool to send scan start scan messages to the notus-scanner. I used MQTT explorer, but Mosquitto also comes with some command line tools.

Acceptance Criteria:
- It should be possible to issue a start scan message with an unknown or missing OS release without crashing notus-scanner
- It should be possible to issue a start scan message with missing package list without crashing notus-scanner
- Corrupt package names in the package list of the start scan message must be ignored
- Missing required information in all messages must be logged and the messages must be ignored
- Failures during the MQTT communication must not crash the daemon
- Failures while loading and parsing the JSON advisory file must be logged and must not result in a crash of the daemon

Message preset:
```json
{
    "message_id": "6072f686-5283-4b04-a87f-2b7c047961bb",
    "group_id": "9b9d2042-14f4-4630-8e10-90736075a13c",
    "message_type": "scan.start",
    "created": 1641404959,
    "scan_id": "97079ee9-8917-49da-aa4f-4ef95f757ac1",
    "host_ip": "127.0.0.1",
    "host_name": null,
    "os_release": "Debian 10",
    "package_list": [
        "firefox-esr-78.15.0esr-1~deb10u1\r"
    ]
}
```

Please try to break notus :)

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/notus-scanner/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
