### PR TITLE
Refactor adjust group_id as defined in eulabeia

### DIFF
--- a/notus/scanner/messages/message.py
+++ b/notus/scanner/messages/message.py
@@ -42,11 +42,11 @@ class Message:
         self,
         *,
         message_id: Optional[UUID] = None,
-        group_id: Optional[UUID] = None,
+        group_id: Optional[str] = None,
         created: Optional[datetime] = None,
     ):
         self.message_id = message_id if message_id else uuid4()
-        self.group_id = group_id if group_id else uuid4()
+        self.group_id = group_id if group_id else str(uuid4())
         self.created = created if created else datetime.utcnow()
 
     @classmethod
@@ -69,12 +69,7 @@ class Message:
             raise MessageParsingError(
                 f"error while parsing 'message_id', {e}"
             ) from e
-        try:
-            group_id = UUID(data.get("group_id"))
-        except (TypeError, ValueError) as e:
-            raise MessageParsingError(
-                f"error while parsing 'group_id', {e}"
-            ) from e
+        group_id = data.get("group_id")
         try:
             created = datetime.fromtimestamp(
                 float(data.get("created")), timezone.utc

--- a/tests/messages/test_message.py
+++ b/tests/messages/test_message.py
@@ -29,7 +29,7 @@ class MessageTestCase(TestCase):
         message = Message()
 
         self.assertIsInstance(message.message_id, UUID)
-        self.assertIsInstance(message.group_id, UUID)
+        self.assertIsInstance(message.group_id, str)
         self.assertIsInstance(message.created, datetime)
 
     def test_serialize(self):
@@ -65,7 +65,7 @@ class MessageTestCase(TestCase):
             message.message_id, UUID("63026767-029d-417e-9148-77f4da49f49a")
         )
         self.assertEqual(
-            message.group_id, UUID("866350e8-1492-497e-b12b-c079287d51dd")
+            message.group_id, "866350e8-1492-497e-b12b-c079287d51dd"
         )
         self.assertEqual(
             message.created,
@@ -134,7 +134,7 @@ class MessageTestCase(TestCase):
             message.message_id, UUID("63026767-029d-417e-9148-77f4da49f49a")
         )
         self.assertEqual(
-            message.group_id, UUID("866350e8-1492-497e-b12b-c079287d51dd")
+            message.group_id, "866350e8-1492-497e-b12b-c079287d51dd"
         )
         self.assertEqual(
             message.created,
@@ -159,29 +159,6 @@ class MessageTestCase(TestCase):
         payload = (
             '{"message_type": "scan.start", '
             '"group_id": "866350e8-1492-497e-b12b-c079287d51dd", '
-            '"created": 1628512774.0}'
-        )
-        Message.message_type = MessageType.SCAN_START
-        with self.assertRaises(MessageParsingError):
-            Message.load(payload)
-        Message.message_type = None
-
-    def test_load_group_id_unvalid(self):
-        payload = (
-            '{"message_id": "63026767-029d-417e-9148-77f4da49f49a", '
-            '"message_type": "scan.start", '
-            '"group_id": "bar", '
-            '"created": 1628512774.0}'
-        )
-        Message.message_type = MessageType.SCAN_START
-        with self.assertRaises(MessageParsingError):
-            Message.load(payload)
-        Message.message_type = None
-
-    def test_load_group_id_missing(self):
-        payload = (
-            '{"message_id": "63026767-029d-417e-9148-77f4da49f49a", '
-            '"message_type": "scan.start", '
             '"created": 1628512774.0}'
         )
         Message.message_type = MessageType.SCAN_START

--- a/tests/messages/test_result.py
+++ b/tests/messages/test_result.py
@@ -37,7 +37,7 @@ class ResultMessageTestCase(TestCase):
         )
 
         self.assertIsInstance(message.message_id, UUID)
-        self.assertIsInstance(message.group_id, UUID)
+        self.assertIsInstance(message.group_id, str)
         self.assertIsInstance(message.created, datetime)
 
         self.assertEqual(message.message_type, MessageType.RESULT)
@@ -109,7 +109,7 @@ class ResultMessageTestCase(TestCase):
             message.message_id, UUID("63026767-029d-417e-9148-77f4da49f49a")
         )
         self.assertEqual(
-            message.group_id, UUID("866350e8-1492-497e-b12b-c079287d51dd")
+            message.group_id, "866350e8-1492-497e-b12b-c079287d51dd"
         )
         self.assertEqual(
             message.created,

--- a/tests/messages/test_start.py
+++ b/tests/messages/test_start.py
@@ -36,7 +36,7 @@ class ScanStartMessageTestCase(TestCase):
         )
 
         self.assertIsInstance(message.message_id, UUID)
-        self.assertIsInstance(message.group_id, UUID)
+        self.assertIsInstance(message.group_id, str)
         self.assertIsInstance(message.created, datetime)
 
         self.assertEqual(message.message_type, MessageType.SCAN_START)
@@ -96,7 +96,7 @@ class ScanStartMessageTestCase(TestCase):
             message.message_id, UUID("63026767-029d-417e-9148-77f4da49f49a")
         )
         self.assertEqual(
-            message.group_id, UUID("866350e8-1492-497e-b12b-c079287d51dd")
+            message.group_id, "866350e8-1492-497e-b12b-c079287d51dd"
         )
         self.assertEqual(
             message.created,

--- a/tests/messages/test_status.py
+++ b/tests/messages/test_status.py
@@ -32,7 +32,7 @@ class ScanStatusMessageTestCase(TestCase):
         )
 
         self.assertIsInstance(message.message_id, UUID)
-        self.assertIsInstance(message.group_id, UUID)
+        self.assertIsInstance(message.group_id, str)
         self.assertIsInstance(message.created, datetime)
 
         self.assertEqual(message.message_type, MessageType.SCAN_STATUS)
@@ -84,7 +84,7 @@ class ScanStatusMessageTestCase(TestCase):
             message.message_id, UUID("63026767-029d-417e-9148-77f4da49f49a")
         )
         self.assertEqual(
-            message.group_id, UUID("866350e8-1492-497e-b12b-c079287d51dd")
+            message.group_id, "866350e8-1492-497e-b12b-c079287d51dd"
         )
         self.assertEqual(
             message.created,


### PR DESCRIPTION
To prevent failures when notus will be integrated into eulabeia the
parsing of group_id to uuid is getting dropped according to:
https://github.com/greenbone/eulabeia/blob/main/docs/messaging.md
