### PR TITLE
Add: possibility to disable product hashsum verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ products-directory = "/tmp/notus/advisories/products"
 pid-file = "/tmp/notus-scanner.pid"
 log-file = "/tmp/notus-scanner.log"
 log-level = "DEBUG"
+disable-hashsum-verification = true
 ```
 
 Each setting can be overridden via an environment variable or command line
@@ -118,7 +119,7 @@ argument.
 |mqtt-broker-port|NOTUS_SCANNER_MQTT_BROKER_PORT|1883|Port of the MQTT broker|
 |pid-file|NOTUS_SCANNER_PID_FILE|/run/notus-scanner/notus-scanner.pid|File for storing the process ID|
 |products-directory|NOTUS_SCANNER_PRODUCTS_DIRECTORY|/var/lib/openvas/plugins/notus/products|Directory for loading product advisories|
-
+|disable-hashsum-verification| NOTUS_DISABLE_HASHSUM_VERIFICATION | To disable hashsum verification of products |
 
 ## Support
 

--- a/notus/scanner/cli/parser.py
+++ b/notus/scanner/cli/parser.py
@@ -125,7 +125,12 @@ class CliParser:
             type=int,
             help="Port of the MQTT broker. (default: %(default)s)",
         )
-
+        parser.add_argument(
+            "--disable-hashsum-verification",
+            type=bool,
+            default=False,
+            help="Disables hashsum verification (default: False)",
+        )
         self.parser = parser
 
     def _set_defaults(self, configfilename=None) -> None:

--- a/notus/scanner/cli/parser.py
+++ b/notus/scanner/cli/parser.py
@@ -129,7 +129,7 @@ class CliParser:
             "--disable-hashsum-verification",
             type=bool,
             default=False,
-            help="Disables hashsum verification (default: False)",
+            help="Disables hashsum verification (default: %(default)s)",
         )
         self.parser = parser
 

--- a/notus/scanner/config.py
+++ b/notus/scanner/config.py
@@ -56,6 +56,11 @@ _CONFIG = (
         DEFAULT_MQTT_BROKER_PORT,
     ),
     ("pid-file", "NOTUS_SCANNER_PID_FILE", DEFAULT_PID_FILE),
+    (
+        "disable-hashsum-verification",
+        "NOTUS_DISABLE_HASHSUM_VERIFICATION",
+        False,
+    ),
 )
 
 

--- a/tests/cli/test_cli_parser.py
+++ b/tests/cli/test_cli_parser.py
@@ -88,6 +88,10 @@ class CliParserTestCase(unittest.TestCase):
         args = self.parse_args(["-f"])
         self.assertTrue(args.foreground)
 
+    def test_disable_hashsum_verification(self):
+        args = self.parse_args(["--disable-hashsum-verification=true"])
+        self.assertTrue(args.disable_hashsum_verification)
+
     def test_defaults(self):
         args = self.parse_args([])
 
@@ -100,6 +104,7 @@ class CliParserTestCase(unittest.TestCase):
         self.assertEqual(args.mqtt_broker_port, DEFAULT_MQTT_BROKER_PORT)
         self.assertEqual(args.mqtt_broker_address, DEFAULT_MQTT_BROKER_ADDRESS)
         self.assertEqual(args.pid_file, DEFAULT_PID_FILE)
+        self.assertEqual(args.disable_hashsum_verification, False)
         self.assertFalse(args.foreground)
 
     def test_config_file_provide_mqtt_broker_address(self):


### PR DESCRIPTION
On a test system it is desireable to disable hashsum verification to
make changes without having to create sha256sums and sign it.
