### PR TITLE
Add: hostname cache for a period of time

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ argument.
 |pid-file|NOTUS_SCANNER_PID_FILE|/run/notus-scanner/notus-scanner.pid|File for storing the process ID|
 |products-directory|NOTUS_SCANNER_PRODUCTS_DIRECTORY|/var/lib/openvas/plugins/notus/products|Directory for loading product advisories|
 |disable-hashsum-verification| NOTUS_DISABLE_HASHSUM_VERIFICATION | To disable hashsum verification of products |
+|cache-result-hostnames-seconds|NOTUS_CACHE_HOSTNAMES_SECONDS| Amount of seconds to cache hostnames for duplicate results. Set to 0 to disable cache.|
 
 ## Support
 

--- a/notus/scanner/cli/parser.py
+++ b/notus/scanner/cli/parser.py
@@ -131,6 +131,15 @@ class CliParser:
             default=False,
             help="Disables hashsum verification (default: %(default)s)",
         )
+        parser.add_argument(
+            "--cache-result-hostnames-seconds",
+            type=int,
+            default=300,
+            help=(
+                "Seconds to cache the hostname of results if present. "
+                "Set to 0 to disable. (default: %(default)s)"
+            ),
+        )
         self.parser = parser
 
     def _set_defaults(self, configfilename=None) -> None:

--- a/notus/scanner/config.py
+++ b/notus/scanner/config.py
@@ -61,6 +61,11 @@ _CONFIG = (
         "NOTUS_DISABLE_HASHSUM_VERIFICATION",
         False,
     ),
+    (
+        "cache-result-hostnames-seconds",
+        "NOTUS_CACHE_HOSTNAMES_SECONDS",
+        300,
+    ),
 )
 
 

--- a/notus/scanner/hostname.py
+++ b/notus/scanner/hostname.py
@@ -1,0 +1,46 @@
+from datetime import datetime, timedelta
+from typing import Dict, List
+from enum import Enum
+import hashlib
+
+from notus.scanner.messages.start import ScanStartMessage
+
+
+class HostNameDecision(Enum):
+    CONTINUE = 0  # hostname is not yet verified or is missing
+    STOP = 1  # hostname has been already verified
+
+
+class HostNameCache:
+    def __init__(self, period: timedelta):
+        self.period = period
+        self.lookup: Dict[str, List[bytes]] = {}
+        self.called: datetime = datetime.now()
+
+    @staticmethod
+    def hash(hostname: str) -> bytes:
+        hasher = hashlib.sha1()
+        hasher.update(bytes(hostname, "utf-8"))
+        return hasher.digest()
+
+    def __in_time(self) -> bool:
+        return datetime.now() < self.called + self.period
+
+    def verify(self, msg: ScanStartMessage) -> HostNameDecision:
+        if not msg.host_name or not msg.scan_id:
+            return HostNameDecision.CONTINUE
+        hashsum = self.hash(msg.host_name)
+        if self.__in_time():
+            cache = self.lookup.get(msg.scan_id, [])
+            for cached_hashsum in cache:
+                if hashsum == cached_hashsum:
+                    return HostNameDecision.STOP
+
+            cache.append(hashsum)
+            self.lookup[msg.scan_id] = cache
+            return HostNameDecision.CONTINUE
+        else:
+            self.called = datetime.now()
+            self.lookup = {}
+
+            return HostNameDecision.CONTINUE

--- a/tests/messages/test_hostname_cache.py
+++ b/tests/messages/test_hostname_cache.py
@@ -1,0 +1,61 @@
+from datetime import timedelta
+from time import sleep
+from unittest import TestCase
+
+from notus.scanner.hostname import HostNameCache, HostNameDecision
+from notus.scanner.messages.start import ScanStartMessage
+
+
+class HostnameCacheTestCase(TestCase):
+    def create_start_scan(
+        self, hostname: str, scan_id: str = "default"
+    ) -> ScanStartMessage:
+        return ScanStartMessage(
+            scan_id=scan_id,
+            host_ip="127.0.0.1",
+            host_name=hostname,
+            os_release="",
+            package_list=[],
+        )
+
+    def test_continue_on_unknown_hostname(self):
+        under_test = HostNameCache(timedelta(seconds=1)).verify
+        result = under_test(self.create_start_scan("testhost"))
+        self.assertEqual(HostNameDecision.CONTINUE, result)
+
+    def test_continue_on_hostname_empty(self):
+        under_test = HostNameCache(timedelta(minutes=1)).verify
+        result = under_test(self.create_start_scan(""))
+        self.assertEqual(HostNameDecision.CONTINUE, result)
+        result = under_test(self.create_start_scan(""))
+        self.assertEqual(HostNameDecision.CONTINUE, result)
+
+    def test_continue_on_hostname_known_but_period_exceeded(self):
+        under_test = HostNameCache(timedelta(microseconds=1)).verify
+        under_test(self.create_start_scan("testhost"))
+        sleep(1)
+        result = under_test(self.create_start_scan("testhost"))
+        self.assertEqual(HostNameDecision.CONTINUE, result)
+
+    def test_stop_on_hostname_found(self):
+        under_test = HostNameCache(timedelta(minutes=1)).verify
+        result = under_test(self.create_start_scan("testhost"))
+        self.assertEqual(HostNameDecision.CONTINUE, result)
+        result = under_test(self.create_start_scan("testhost"))
+        self.assertEqual(HostNameDecision.STOP, result)
+
+    def test_continue_on_missing_scan_id(self):
+        under_test = HostNameCache(timedelta(minutes=1)).verify
+        result = under_test(self.create_start_scan("testhost", scan_id=""))
+        self.assertEqual(HostNameDecision.CONTINUE, result)
+        result = under_test(self.create_start_scan("testhost", scan_id=""))
+        self.assertEqual(HostNameDecision.CONTINUE, result)
+
+    def test_continue_on_hostname_known_but_different_scan_id(self):
+        under_test = HostNameCache(timedelta(minutes=1)).verify
+        result = under_test(self.create_start_scan("testhost"))
+        self.assertEqual(HostNameDecision.CONTINUE, result)
+        result = under_test(
+            self.create_start_scan("testhost", scan_id="another one")
+        )
+        self.assertEqual(HostNameDecision.CONTINUE, result)


### PR DESCRIPTION
It can happen that a hostname will be send twice. One per IPv4 and once
IPv6 per hostname. To mitigate that scenario somewhat there is cache for
5 minutes to store a hash value of a host and verify if it already got
  scanned recently.

**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/notus-scanner/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
