### PR TITLE
Add: possibility to add range for packages

### DIFF
--- a/notus/scanner/loader/json.py
+++ b/notus/scanner/loader/json.py
@@ -146,6 +146,8 @@ class JSONAdvisoriesLoader(AdvisoriesLoader):
                     )
                     continue
 
-                package_advisories.add_advisory_for_package(package, advisory)
+                package_advisories.add_advisory_for_package(
+                    package, advisory, package_dict.get("specifier")
+                )
 
         return package_advisories

--- a/notus/scanner/scanner.py
+++ b/notus/scanner/scanner.py
@@ -100,7 +100,7 @@ Fixed version: {vulnerability.fixed_package.full_name}"""
                 package_advisories.get_package_advisories_for_package(package)
             )
             for package_advisory in package_advisory_list:
-                if package_advisory.package > package:
+                if package_advisory.is_vulnerable(package):
                     yield PackageVulnerability(
                         host_ip=host_ip,
                         host_name=host_name,

--- a/tests/fakespecifier_os.notus
+++ b/tests/fakespecifier_os.notus
@@ -1,0 +1,35 @@
+{
+  "version": "1.0",
+  "package_type": "rpm",
+  "product_name": "FakeSpecifier OS",
+  "advisories": [
+    {
+      "oid": "0.0.0.0.0.0.0.0.0.0.0.1",
+      "fixed_packages": [
+        {
+          "full_name": "eq-9.2.15-1.x86_64",
+          "specifier": "="
+        },
+        {
+          "full_name": "lt-9.2.15-1.x86_64",
+          "specifier": "<"
+        },
+        {
+          "full_name": "le-9.2.15-1.x86_64",
+          "specifier": "<="
+        },
+        {
+          "full_name": "gt-9.2.15-1.x86_64",
+          "specifier": ">"
+        },
+        {
+          "full_name": "ge-9.2.15-1.x86_64",
+          "specifier": ">="
+        },
+        {
+          "full_name": "default-9.2.15-1.x86_64"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/models/packages/test_package.py
+++ b/tests/models/packages/test_package.py
@@ -111,7 +111,9 @@ class PackageAdvisoryTestCase(TestCase):
             oid="1.2.3.4.5",
         )
 
-        package_advisory = PackageAdvisory(package=package, advisory=advisory)
+        package_advisory = PackageAdvisory(
+            package=package, advisory=advisory, is_vulnerable=lambda _: False
+        )
 
         self.assertEqual(package_advisory.package, package)
         self.assertEqual(package_advisory.advisory, advisory)
@@ -130,7 +132,9 @@ class PackageAdvisoryTestCase(TestCase):
             oid="1.2.3.4.6",
         )
 
-        package_advisory = PackageAdvisory(package=package1, advisory=advisory1)
+        package_advisory = PackageAdvisory(
+            package=package1, advisory=advisory1, is_vulnerable=lambda _: False
+        )
 
         with self.assertRaises(FrozenInstanceError):
             package_advisory.package = package2
@@ -156,16 +160,16 @@ class PackageAdvisoryTestCase(TestCase):
         )
 
         package_advisory1 = PackageAdvisory(
-            package=package1, advisory=advisory1
+            package=package1, advisory=advisory1, is_vulnerable=lambda _: False
         )
         package_advisory2 = PackageAdvisory(
-            package=package2, advisory=advisory2
+            package=package2, advisory=advisory2, is_vulnerable=lambda _: False
         )
         package_advisory3 = PackageAdvisory(
-            package=package1, advisory=advisory1
+            package=package1, advisory=advisory1, is_vulnerable=lambda _: False
         )
         package_advisory4 = PackageAdvisory(
-            package=package1, advisory=advisory2
+            package=package1, advisory=advisory2, is_vulnerable=lambda _: False
         )
 
         self.assertEqual(package_advisory1, package_advisory1)
@@ -190,16 +194,16 @@ class PackageAdvisoryTestCase(TestCase):
         )
 
         package_advisory1 = PackageAdvisory(
-            package=package1, advisory=advisory1
+            package=package1, advisory=advisory1, is_vulnerable=lambda _: False
         )
         package_advisory2 = PackageAdvisory(
-            package=package2, advisory=advisory2
+            package=package2, advisory=advisory2, is_vulnerable=lambda _: False
         )
         package_advisory3 = PackageAdvisory(
-            package=package1, advisory=advisory1
+            package=package1, advisory=advisory1, is_vulnerable=lambda _: False
         )
         package_advisory4 = PackageAdvisory(
-            package=package1, advisory=advisory2
+            package=package1, advisory=advisory2, is_vulnerable=lambda _: False
         )
 
         self.assertEqual(hash(package_advisory1), hash(package_advisory1))
@@ -228,9 +232,29 @@ class PackageAdvisoriesTestCase(TestCase):
 
         self.assertEqual(len(package_advisories), 0)
 
-        package_advisories.add_advisory_for_package(package, advisory)
+        package_advisories.add_advisory_for_package(package, advisory, None)
 
         self.assertEqual(len(package_advisories), 1)
+
+    def test_default_is_vulnerable(self):
+        package_advisories = PackageAdvisories(PackageType.RPM)
+        package = RPMPackage.from_full_name(
+            "foo-1.2.3-3.aarch64",
+        )
+        advisory = AdvisoryReference(
+            oid="1.2.3.4.5",
+        )
+
+        other = RPMPackage.from_full_name(
+            "foo-1.2.4-3.aarch64",
+        )
+        package_advisories.add_advisory_for_package(package, advisory, None)
+        advisories = package_advisories.get_package_advisories_for_package(
+            other
+        )
+        self.assertEqual(1, len(advisories))
+        for adv in advisories:
+            self.assertFalse(adv.is_vulnerable(other))
 
     def test_add_duplicate_advisory_for_package(self):
         package_advisories = PackageAdvisories(package_type=PackageType.RPM)
@@ -249,23 +273,23 @@ class PackageAdvisoriesTestCase(TestCase):
 
         self.assertEqual(len(package_advisories), 0)
 
-        package_advisories.add_advisory_for_package(package1, advisory1)
+        package_advisories.add_advisory_for_package(package1, advisory1, None)
 
         self.assertEqual(len(package_advisories), 1)
 
-        package_advisories.add_advisory_for_package(package1, advisory1)
+        package_advisories.add_advisory_for_package(package1, advisory1, None)
 
         self.assertEqual(len(package_advisories), 1)
 
-        package_advisories.add_advisory_for_package(package1, advisory2)
+        package_advisories.add_advisory_for_package(package1, advisory2, None)
 
         self.assertEqual(len(package_advisories), 1)
 
-        package_advisories.add_advisory_for_package(package2, advisory1)
+        package_advisories.add_advisory_for_package(package2, advisory1, None)
 
         self.assertEqual(len(package_advisories), 1)
 
-        package_advisories.add_advisory_for_package(package2, advisory2)
+        package_advisories.add_advisory_for_package(package2, advisory2, None)
 
     def test_get_package_advisories_for_package(self):
         package_advisories = PackageAdvisories(package_type=PackageType.RPM)
@@ -284,9 +308,9 @@ class PackageAdvisoriesTestCase(TestCase):
 
         self.assertEqual(len(package_advisories), 0)
 
-        package_advisories.add_advisory_for_package(package1, advisory1)
-        package_advisories.add_advisory_for_package(package1, advisory2)
-        package_advisories.add_advisory_for_package(package2, advisory2)
+        package_advisories.add_advisory_for_package(package1, advisory1, None)
+        package_advisories.add_advisory_for_package(package1, advisory2, None)
+        package_advisories.add_advisory_for_package(package2, advisory2, None)
 
         advisories1 = package_advisories.get_package_advisories_for_package(
             package1

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -1,0 +1,117 @@
+# Copyright (C) 2021 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+import json
+from typing import List, Optional, Tuple
+import unittest
+from pathlib import Path
+
+
+from notus.scanner.messages.start import ScanStartMessage
+from notus.scanner.messages.message import Message
+from notus.scanner.messaging.publisher import Publisher
+from notus.scanner.scanner import NotusScanner
+from notus.scanner.loader.gpg_sha_verifier import VerificationResult
+from notus.scanner.loader.json import JSONAdvisoriesLoader
+
+_here = Path(__file__).parent
+
+
+class FakePublisher(Publisher):
+    def __init__(self):
+        self.results = []
+
+    def publish(self, message: Message) -> None:
+        serialized = message.serialize()
+        values = str(serialized.get("value", "")).split("\n")
+        if len(values) > 2:
+            installed = values[1][len("Installed version: ") :].strip()
+            self.results.append(installed)
+
+
+class VerifierTestCase(unittest.TestCase):
+    """
+    VerifierTestCase loads a notus advisory for FakeSpecifierOS
+    and iterates through defined fixed packages and their specifier
+    to generate and test them.
+    """
+
+    def per_symbol(
+        self, name: str, verifier: Optional[str]
+    ) -> Tuple[List[str], List[str]]:
+        """
+        returns not_in_result and in result
+        """
+        greater = lambda: name.replace("15", "16")
+        smaller = lambda: name.replace("15", "14")
+        if not verifier:
+            return [greater(), name], [smaller()]
+        if verifier == ">":
+            return [greater()], [name, smaller()]
+        if verifier == ">=":
+            return [greater(), name], [smaller()]
+        if verifier == "<":
+            return [smaller()], [name, greater()]
+        if verifier == "<=":
+            return [smaller(), name], [greater()]
+        return [name], [smaller(), greater()]
+
+    def generate_test_cases(self):
+        jdict = json.loads((_here / "fakespecifier_os.notus").read_bytes())
+        fixed_packages = (
+            f.get("fixed_packages", []) for f in jdict.get("advisories", {})
+        )
+        cases = (
+            (fp.get("full_name"), fp.get("specifier"))
+            for fps in fixed_packages
+            for fp in fps
+        )
+        # cases that should not appear in resul
+        not_in = []
+        # cases that should appear in result
+        is_in = []
+        for verylongvariablenamecaseforpylint in cases:
+            c_not_in, c_is_in = self.per_symbol(
+                *verylongvariablenamecaseforpylint
+            )
+            not_in = not_in + c_not_in
+            is_in = is_in + c_is_in
+        # packagelist is both combined
+        return not_in + is_in, not_in, is_in
+
+    def test_verifier(self):
+        loader = JSONAdvisoriesLoader(
+            advisories_directory_path=_here,
+            verify=lambda _: VerificationResult.SUCCESS,
+        )
+        publisher = FakePublisher()
+        scanner = NotusScanner(loader, publisher)
+        pkg_list, not_in_results, in_results = self.generate_test_cases()
+        msg = ScanStartMessage(
+            scan_id="scanus praktikus",
+            os_release="FakeSpecifier OS",
+            host_ip="127.0.0.2",
+            host_name="localhorst",
+            package_list=pkg_list,
+        )
+        scanner.run_scan(msg)
+        results = set(publisher.results)
+        self.assertEqual(len(results), len(publisher.results))
+
+        self.assertEqual(set(), results.intersection(not_in_results))
+
+        self.assertEqual(set(in_results), results.intersection(in_results))


### PR DESCRIPTION
This commits adds the possibility to control verify statements by
adding a specifier to the fixed_packages:

```
{
    "name": null,
    "full_version": null,
    "full_name": "xorg-x11-server-1.7.6.src",
    "specifier": "<"
},
```

Defined specifiers are:

- `<` packages smaller than specified version are fixed
- `>` packages greater than specified version are fixed
- `<=` packages smaller or equal than specified version are fixed
- `>=` packages greather or equal than specified version are fixed
- `=` packages equal to specified version are fixed

When no specifier is added than it defautls to `>=`.