### PR TITLE
Fix: docker image by adding tomli, packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,8 @@ paho-mqtt = "^1.6"
 psutil = "^5.9"
 sentry-sdk = {version = "^1.5.3", optional = true}
 python-gnupg = "^0.4.8"
+tomli = "<2.0.0"
+packaging = "<21.3"
 
 [tool.poetry.extras]
 sentry = ["sentry-sdk"]


### PR DESCRIPTION
The pyproject did not contain the packaging as well as tomli definition
and was therefore missing both in the docker image.

Unfortunately due to the dependency on pontos both versions needed to be
pinned down.
