### PR TITLE
Add: internal gather package list

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ pid-file = "/tmp/notus-scanner.pid"
 log-file = "/tmp/notus-scanner.log"
 log-level = "DEBUG"
 disable-hashsum-verification = true
+ssh-policy = "add"
 ```
 
 Each setting can be overridden via an environment variable or command line
@@ -119,8 +120,23 @@ argument.
 |mqtt-broker-port|NOTUS_SCANNER_MQTT_BROKER_PORT|1883|Port of the MQTT broker|
 |pid-file|NOTUS_SCANNER_PID_FILE|/run/notus-scanner/notus-scanner.pid|File for storing the process ID|
 |products-directory|NOTUS_SCANNER_PRODUCTS_DIRECTORY|/var/lib/openvas/plugins/notus/products|Directory for loading product advisories|
-|disable-hashsum-verification| NOTUS_DISABLE_HASHSUM_VERIFICATION | To disable hashsum verification of products |
+|disable-hashsum-verification| NOTUS_DISABLE_HASHSUM_VERIFICATION | false | To disable hashsum verification of products |
+|ssh-policy| NOTUS_SCANNER_SSH_POLICY | reject | Set ssh policy (add, warn, reject) |
+|ssh-host-keyfile"| NOTUS_SCANNER_SSH_HOST_KEYFILE | None | Path to a keyfile which contains key of known host. Used for ssh connection |
+|ssh-system-host-keys| NOTUS_SCANNER_SSH_SYSTEM_HOST_KEYS | True | Enable loading the local known hosts keyfile of the current user |
 
+### SSH-Options
+
+The `ssh-policy` option determines what happens when connecting to a unknown
+host via ssh. There are 3 possible settings:
+- `add`: Policy for automatically adding the hostname and new key
+- `warn`: Policy for logging a warning for an unknown host key, but accepting it
+- `reject`: Policy for automatically rejecting the unknown hostname and key
+
+In order for the notus-scanner to find known hosts, there are two ways to add
+them. The `ssh-host-keyfile` option enables to pass a path to a keyfile which
+should contain keys from known hosts. In addition Notus-Scanner can try to
+load a local keyfile in the default path of the current user.
 ## Support
 
 For any question on the usage of Notus Scanner please use the

--- a/notus/scanner/cli/parser.py
+++ b/notus/scanner/cli/parser.py
@@ -76,14 +76,17 @@ class CliParser:
             "-c",
             "--config",
             nargs="?",
-            help="Configuration file path. If not set %(prog)s "
-            f"tries to load {DEFAULT_USER_CONFIG_FILE} and "
-            f"{DEFAULT_CONFIG_FILE}.",
+            help=(
+                "Configuration file path. If not set %(prog)s "
+                f"tries to load {DEFAULT_USER_CONFIG_FILE} and "
+                f"{DEFAULT_CONFIG_FILE}."
+            ),
         )
         parser.add_argument(
             "--pid-file",
-            help="Location of the file for the process ID "
-            "(default: %(default)s)",
+            help=(
+                "Location of the file for the process ID (default: %(default)s)"
+            ),
         )
         parser.add_argument(
             "-l",
@@ -116,8 +119,10 @@ class CliParser:
             "-b",
             "--mqtt-broker-address",
             type=str,
-            help="Hostname or IP address of the MQTT broker. "
-            "(default: %(default)s)",
+            help=(
+                "Hostname or IP address of the MQTT broker. "
+                "(default: %(default)s)"
+            ),
         )
         parser.add_argument(
             "-p",
@@ -130,6 +135,33 @@ class CliParser:
             type=bool,
             default=False,
             help="Disables hashsum verification (default: %(default)s)",
+        )
+        parser.add_argument(
+            "--ssh-policy",
+            type=str,
+            default="reject",
+            help=(
+                "Choose Policy for new SSH-connections (add, warn, reject). For"
+                " more Information read Documentation. (defualt: %(default)s)"
+            ),
+        )
+        parser.add_argument(
+            "--ssh-host-keyfile",
+            type=str,
+            default="",
+            help=(
+                "Path to keyfile with known hosts for ssh-connection. (default:"
+                " None)"
+            ),
+        )
+        parser.add_argument(
+            "--ssh-system-host-keys",
+            type=bool,
+            default=True,
+            help=(
+                "Choose if known hosts for ssh should be loaded from the"
+                " system. (default: %(default)s)"
+            ),
         )
         self.parser = parser
 

--- a/notus/scanner/config.py
+++ b/notus/scanner/config.py
@@ -36,6 +36,7 @@ DEFAULT_LOG_LEVEL = "INFO"
 DEFAULT_MQTT_BROKER_ADDRESS = "localhost"
 DEFAULT_MQTT_BROKER_PORT = 1883
 DEFAULT_PID_FILE = "/run/notus-scanner/notus-scanner.pid"
+DEFULT_SSH_POLICY = "reject"
 
 _CONFIG = (
     (
@@ -60,6 +61,21 @@ _CONFIG = (
         "disable-hashsum-verification",
         "NOTUS_DISABLE_HASHSUM_VERIFICATION",
         False,
+    ),
+    (
+        "ssh-policy",
+        "NOTUS_SCANNER_SSH_POLICY",
+        DEFULT_SSH_POLICY,
+    ),
+    (
+        "ssh-host-keyfile",
+        "NOTUS_SCANNER_SSH_HOST_KEYFILE",
+        "",
+    ),
+    (
+        "ssh-system-host-keys",
+        "NOTUS_SCANNER_SSH_SYSTEM_HOST_KEYS",
+        True,
     ),
 )
 

--- a/notus/scanner/errors.py
+++ b/notus/scanner/errors.py
@@ -24,6 +24,14 @@ class AdvisoriesLoadingError(NotusScannerError):
     """A problem while loading an Advisory has occurred"""
 
 
+class UnknownSSHPolicyError(NotusScannerError):
+    """Unknown given ssh policy for unknown host keys"""
+
+
+class NotAFielError(NotusScannerError):
+    """A problem while checking for a Filepath"""
+
+
 class Sha256SumLoadingError(NotusScannerError):
     """A problem while loading sha256sums has occurred"""
 

--- a/notus/scanner/messages/result.py
+++ b/notus/scanner/messages/result.py
@@ -20,7 +20,7 @@ from enum import Enum
 from typing import Dict, Union, Any, Optional
 from uuid import UUID
 
-from notus.scanner.errors import MessageParsingError
+from ..errors import MessageParsingError
 
 from .message import Message, MessageType
 

--- a/notus/scanner/messages/start.py
+++ b/notus/scanner/messages/start.py
@@ -19,7 +19,7 @@ from datetime import datetime
 from typing import Dict, Union, Any, List, Optional
 from uuid import UUID
 
-from notus.scanner.errors import MessageParsingError
+from ..errors import MessageParsingError
 
 from .message import Message, MessageType
 
@@ -83,6 +83,69 @@ class ScanStartMessage(Message):
                 "host_name": data.get("host_name"),
                 "os_release": data.get("os_release"),
                 "package_list": package_list,
+            }
+        )
+        return kwargs
+
+
+class ScanHostsMessage(Message):
+    message_type: MessageType = MessageType.SCAN_START
+    topic = "scanner/scan/cmd/notus"
+
+    scan_id: str
+    hosts: Dict[str, str]
+    ssh_login: str
+    ssh_password: str
+
+    def __init__(
+        self,
+        *,
+        scan_id: str,
+        hosts: Dict[str, str],
+        ssh_login: str,
+        ssh_password: Optional[str] = "",
+        ssh_key: Optional[str] = "",
+        ssh_port: Optional[int] = 22,
+        message_id: Optional[UUID] = None,
+        group_id: Optional[str] = None,
+        created: Optional[datetime] = None,
+    ):
+        super().__init__(
+            message_id=message_id, group_id=group_id, created=created
+        )
+        self.scan_id = scan_id
+        self.hosts = hosts
+        self.ssh_login = ssh_login
+        self.ssh_password = ssh_password
+        self.ssh_key = ssh_key
+        self.ssh_port = ssh_port
+
+    def serialize(self) -> Dict[str, Union[int, str, List[str]]]:
+        message = super().serialize()
+        message.update(
+            {
+                "scan_id": self.scan_id,
+                "hosts": self.hosts,
+                "ssh_login": self.ssh_login,
+                "ssh_password": self.ssh_password,
+                "ssh_key": self.ssh_key,
+                "ssh_port": self.ssh_port,
+            }
+        )
+        return message
+
+    @classmethod
+    def _parse(cls, data: Dict[str, Union[int, str]]) -> Dict[str, Any]:
+        kwargs = super()._parse(data)
+
+        kwargs.update(
+            {
+                "scan_id": data.get("scan_id"),
+                "hosts": data.get("hosts"),
+                "ssh_login": data.get("ssh_login"),
+                "ssh_password": data.get("ssh_password"),
+                "ssh_key": data.get("ssh_key"),
+                "ssh_port": data.get("ssh_port"),
             }
         )
         return kwargs

--- a/notus/scanner/messaging/mqtt.py
+++ b/notus/scanner/messaging/mqtt.py
@@ -23,7 +23,7 @@ from typing import Callable, Type
 
 import paho.mqtt.client as mqtt
 
-from notus.scanner.errors import MessageParsingError
+from ..errors import MessageParsingError
 
 from ..messages.message import Message
 

--- a/notus/scanner/models/os/__init__.py
+++ b/notus/scanner/models/os/__init__.py
@@ -1,0 +1,16 @@
+# Copyright (C) 2021-2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.

--- a/notus/scanner/models/os/debian.py
+++ b/notus/scanner/models/os/debian.py
@@ -1,0 +1,69 @@
+# Copyright (C) 2021-2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import re
+from typing import Optional
+from paramiko import SSHClient
+
+from .distribution import Distribution
+
+logger = logging.getLogger(__name__)
+
+
+_debian_re = re.compile(r"^([0-9]+)([0-9.]+)")
+
+
+class Debian(Distribution):
+    @staticmethod
+    def get_os(ssh: SSHClient) -> Optional[str]:
+        # Try Debian
+        rls = Debian.command(ssh, "cat /etc/debian_version")
+        if (
+            _debian_re.match(rls)
+            or rls.find("buster/sid") >= 0
+            or rls.find("bullseye/sid") >= 0
+        ):
+            # It still can be Ubuntu
+            if Debian.command(ssh, "cat /etc/lsb-release"):
+                return
+            # It is Debian
+            os = "debian_"
+            # Getting Version
+            try:
+                versions = _debian_re.match(rls).groups()
+                v1 = int(versions[0])
+                if v1 <= 3:  # version 3 needs the minor version as well
+                    os = os + versions[0] + versions[1]
+                else:  # versions grater than 3 only needs the major version
+                    os = os + versions[0]
+                return os
+            except (AttributeError, ValueError):
+                logger.debug("Not supported Debian Version: %s", rls)
+            except IndexError:
+                logger.warning(
+                    "Regular Expression %s might be incorrect",
+                    _debian_re.pattern,
+                )
+
+    @staticmethod
+    def gather_package_list(ssh: SSHClient) -> list[str]:
+        packages_str = Debian.command(
+            ssh, r"dpkg-query -W -f=\$\{Package\}-\$\{Version\}'\n'"
+        )
+        packages = packages_str.strip().splitlines()
+        return packages

--- a/notus/scanner/models/os/distribution.py
+++ b/notus/scanner/models/os/distribution.py
@@ -1,0 +1,44 @@
+# Copyright (C) 2021-2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Optional
+from paramiko import SSHClient
+
+
+class Distribution:
+    """Distribution is the Base Class for all Distributions supported by the
+    notus scanner. I contains methods to optain the corresponding distribution
+    release with version and the package list."""
+
+    @staticmethod
+    def get_os(ssh: SSHClient) -> Optional[str]:
+        """Get the operating system, if the ssh client is connected to the
+        coresponding distribution"""
+        raise NotImplementedError
+
+    @staticmethod
+    def gather_package_list(ssh: SSHClient) -> list[str]:
+        """Get the package list of the system, the ssh client is connected to.
+        The ssh client must be connected to the corresponding distribution"""
+        raise NotImplementedError
+
+    @staticmethod
+    def command(ssh: SSHClient, command: str) -> str:
+        """Executes a given command via a given ssh connection and returns the
+        stdout as a string"""
+        _, ssh_stdout, _ = ssh.exec_command(command)
+        return ssh_stdout.read().decode("utf-8")

--- a/notus/scanner/models/os/euleros.py
+++ b/notus/scanner/models/os/euleros.py
@@ -1,0 +1,87 @@
+# Copyright (C) 2021-2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import re
+from typing import List, Optional
+from paramiko import SSHClient
+from .distribution import Distribution
+
+logger = logging.getLogger(__name__)
+
+# EulerOS 2.0
+_euler_re = re.compile(
+    r"EulerOS release ([0-9]+\.[0-9]+)\s?(\((SP[0-9]+)(x86_64)?\))?"
+)
+# EulerOS Virtualzations
+_euler_v_re = re.compile(r"EulerOS Virtualization ([a-zA-Z0-9 ]+) ([0-9.]+)")
+
+
+class EulerOS(Distribution):
+    @staticmethod
+    def get_os(ssh: SSHClient) -> Optional[str]:
+        # Try EulerOS
+        os = None
+        rls = EulerOS.command(ssh, "cat /etc/euleros-release")
+        if rls.find("EulerOS release") >= 0:
+            # Euler OS release 2.0 ...
+            try:
+                rls_match = _euler_re.match(rls).groups()
+                if rls_match[0]:
+                    os = "euleros_v" + rls_match[0]
+                if rls_match[2]:
+                    os = os + rls_match[2].lower()
+                else:
+                    os = os + rls_match + "sp0"
+                if rls_match[3]:
+                    os = os + "(" + rls_match[3] + ")"
+            except ValueError:
+                os = None
+            except IndexError:
+                logger.warning(
+                    "Regular Expression %s might be incorrect",
+                    _euler_re.pattern,
+                )
+
+            # Euler OS Virtualization ...
+            try:
+                rls = EulerOS.command(ssh, "cat /etc/uvp-release")
+                if rls.find("EulerOS Virtualization") >= 0:
+                    rls_match = _euler_v_re.match(rls).groups()
+                    if rls_match[0]:
+                        os = "euleros_virtualization_"
+                        if rls_match[0].find("for ARM 64") >= 0:
+                            os = os + "for_arm_64_"
+                        if rls_match[1]:
+                            os = os + rls_match[1]
+            except ValueError:
+                os = None
+            except IndexError:
+                logger.warning(
+                    "Regular Expression %s might be incorrect",
+                    _euler_re.pattern,
+                )
+
+        return os
+
+    @staticmethod
+    def gather_package_list(ssh: SSHClient) -> List[str]:
+        packages_str = EulerOS.command(
+            ssh, "/bin/rpm -qa --qf '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n'"
+        )
+        packages = packages_str.strip().splitlines()
+        return packages

--- a/notus/scanner/models/os/suse.py
+++ b/notus/scanner/models/os/suse.py
@@ -1,0 +1,52 @@
+# Copyright (C) 2021-2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+import re
+from typing import Optional
+from paramiko import SSHClient
+from .distribution import Distribution
+
+_suse_re = re.compile(r"(open)?suse( leap| linux)?([a-zA-Z0-9 ]+)")
+
+
+class SuSE(Distribution):
+    @staticmethod
+    def get_os(ssh: SSHClient) -> Optional[str]:
+        # Try SuSE
+        os = None
+        rls = SuSE.command(ssh, "cat /etc/os-release")
+        if not rls:
+            rls = SuSE.command(ssh, "cat /usr/lib/os-release")
+
+        if _suse_re.match(rls) and rls.find("enterprise") == -1:
+            if rls.find("opensuse leap"):
+                os = "opensuseleap"
+            elif rls.find("opensuse"):
+                os = "opensuse"
+            else:
+                os = "suse"
+            # Other SuSE Versions?
+
+        return os
+
+    @staticmethod
+    def gather_package_list(ssh: SSHClient) -> list[str]:
+        packages_str = SuSE.command(
+            ssh, "/bin/rpm -qa --qf '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n'"
+        )
+        packages = packages_str.strip().splitlines()
+        return packages

--- a/notus/scanner/models/packages/deb.py
+++ b/notus/scanner/models/packages/deb.py
@@ -65,6 +65,7 @@ class DEBPackage(Package):
         if not full_name:
             return None
 
+        full_name = full_name.strip()
         # Try to get data with
         try:
             name, epoch, upstream_version, debian_revision = _deb_compile.match(

--- a/notus/scanner/models/packages/rpm.py
+++ b/notus/scanner/models/packages/rpm.py
@@ -60,12 +60,14 @@ class RPMPackage(Package):
         if not full_name:
             return None
 
+        full_name = full_name.strip()
+
         try:
             name, version, release, architecture = _rpm_compile.match(
                 full_name
             ).groups()
             try:
-                arch = Architecture(architecture.strip())
+                arch = Architecture(architecture)
             except ValueError:
                 arch = Architecture.UNKNOWN
         except AttributeError:

--- a/notus/scanner/scanner.py
+++ b/notus/scanner/scanner.py
@@ -16,7 +16,23 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-from typing import Generator, Iterable
+from socket import error as SocketError
+from typing import Generator, Iterable, Optional
+
+from paramiko import (
+    AuthenticationException,
+    AutoAddPolicy,
+    BadHostKeyException,
+    MissingHostKeyPolicy,
+    RejectPolicy,
+    SSHClient,
+    SSHException,
+    WarningPolicy,
+)
+from notus.scanner.models.os.debian import Debian
+from notus.scanner.models.os.distribution import Distribution
+from notus.scanner.models.os.euleros import EulerOS
+from notus.scanner.models.os.suse import SuSE
 
 from notus.scanner.models.packages.deb import DEBPackage
 
@@ -24,14 +40,23 @@ from .errors import AdvisoriesLoadingError
 from .loader import AdvisoriesLoader
 from .messages.message import Message
 from .messages.result import ResultMessage
-from .messages.start import ScanStartMessage
+from .messages.start import ScanHostsMessage, ScanStartMessage
 from .messages.status import ScanStatus, ScanStatusMessage
 from .messaging.publisher import Publisher
 from .models.packages.package import Package, PackageAdvisories, PackageType
 from .models.packages.rpm import RPMPackage
 from .models.vulnerability import PackageVulnerability
 
+
+SUPPORTED_DISTRIBUTIONS: list[type[Distribution]] = [Debian, EulerOS, SuSE]
+SSH_POLICY: dict[str, type[MissingHostKeyPolicy]] = {
+    "add": AutoAddPolicy,
+    "warn": WarningPolicy,
+    "reject": RejectPolicy,
+}
+
 logger = logging.getLogger(__name__)
+logging.getLogger("paramiko").setLevel(logging.WARNING)
 
 
 class NotusScanner:
@@ -39,9 +64,15 @@ class NotusScanner:
         self,
         loader: AdvisoriesLoader,
         publisher: Publisher,
+        ssh_policy: SSH_POLICY,
+        ssh_host_keyfile: str,
+        ssh_system_host_keys: bool,
     ):
         self._loader = loader
         self._publisher = publisher
+        self._ssh_policy = ssh_policy
+        self._ssh_host_keyfile = ssh_host_keyfile
+        self._ssh_system_host_keys = ssh_system_host_keys
 
     def _publish(self, message: Message):
         """Try to publish a message
@@ -109,37 +140,105 @@ Fixed version: {vulnerability.fixed_package.full_name}"""
                         advisory=package_advisory.advisory,
                     )
 
+    def scan_hosts_ssh(self, msg: ScanHostsMessage) -> None:
+        """Handles Data given with ScanHostMessage and runs scan. The Message
+        must contain credentials to setup a SSH connection to get the required
+        os release and package list. If no SSH cannot connect to the host, it
+        just get skipped."""
+        ssh = SSHClient()
+        ssh.set_missing_host_key_policy(self._ssh_policy())
+        if self._ssh_host_keyfile:
+            ssh.load_host_keys(self._ssh_host_keyfile)
+        if self._ssh_system_host_keys:
+            ssh.load_system_host_keys()
+
+        for ip, host in msg.hosts.items():
+            try:
+                if msg.ssh_key:
+                    ssh.connect(
+                        hostname=ip,
+                        port=msg.ssh_port,
+                        username=msg.ssh_login,
+                        password=msg.ssh_password,
+                        pkey=msg.ssh_key,
+                        look_for_keys=False,
+                    )
+                else:
+                    ssh.connect(
+                        hostname=ip,
+                        port=msg.ssh_port,
+                        username=msg.ssh_login,
+                        password=msg.ssh_password,
+                        look_for_keys=False,
+                        timeout=3,
+                    )
+                os = None
+                for dist in SUPPORTED_DISTRIBUTIONS:
+                    os = dist.get_os(ssh)
+                    if os is not None:
+                        pl = dist.gather_package_list(ssh)
+                        break
+                ssh.close()
+
+                if os is not None and pl:
+                    self.run_scan(msg.scan_id, ip, host, os, pl)
+                else:
+                    logger.debug(
+                        "Unable to scan %s. The OS is probably not supported"
+                        " yet.",
+                        ip,
+                    )
+            except (
+                BadHostKeyException,
+                AuthenticationException,
+                SSHException,
+                SocketError,
+            ) as e:
+                logger.debug(
+                    "Unable to establish SSH connection for %s. Host is"
+                    " excluded from scan. Error was: %s",
+                    ip,
+                    e,
+                )
+
+    def scan_host_package_list(self, msg: ScanStartMessage) -> None:
+        """Handles Data given with ScanStartMessage and runs scan. The Message
+        must contains the required os release and package list."""
+        self.run_scan(
+            msg.scan_id,
+            msg.host_ip,
+            msg.host_name,
+            msg.os_release,
+            msg.package_list,
+        )
+
     def run_scan(
         self,
-        message: ScanStartMessage,
+        scan_id: str,
+        host_ip: str,
+        host_name: Optional[str],
+        os_release: str,
+        package_list: list[str],
     ) -> None:
-        """Handle the data necessary to start a scan,
-        received via mqtt and run the scan."""
+        """Runs a scan with given data."""
 
-        # Check if all necessary information to run a scan are given
-        if not message:
-            logger.error(
-                "Unable to start scan for %s: The message seems to be empty",
-                message.host_ip,
-            )
-            return
-        if not message.os_release:
+        if not os_release:
             logger.error(
                 "Unable to start scan for %s: The field os_release is empty",
-                message.host_ip,
+                host_ip,
             )
             return
-        if not message.package_list:
+        if not package_list:
             logger.error(
                 "Unable to start scan for %s: The field package_list is empty",
-                message.host_ip,
+                host_ip,
             )
             return
 
         # Get advisory information from disk
         try:
             package_advisories = self._loader.load_package_advisories(
-                message.os_release
+                os_release
             )
         except AdvisoriesLoadingError as e:
             logger.error("Unable to load package advisories. Error was %s", e)
@@ -151,8 +250,8 @@ Fixed version: {vulnerability.fixed_package.full_name}"""
                 "Unable to start scan for %s: No advisories for OS-release %s"
                 " found. Check if the OS-release is correct and the"
                 " corresponding advisories are given.",
-                message.host_ip,
-                message.os_release,
+                host_ip,
+                os_release,
             )
             return
 
@@ -163,7 +262,7 @@ Fixed version: {vulnerability.fixed_package.full_name}"""
             DEBPackage if package_type == PackageType.DEB else RPMPackage
         )
         may_installed = [
-            package_class.from_full_name(name) for name in message.package_list
+            package_class.from_full_name(name) for name in package_list
         ]
         # a package in may_installed can only be None when .from_full_name fails
         # they both log a warning when they're unable to parse that hence it
@@ -172,28 +271,28 @@ Fixed version: {vulnerability.fixed_package.full_name}"""
             package for package in may_installed if package is not None
         )
 
-        self._start_host(message.scan_id, message.host_ip)
+        self._start_host(scan_id, host_ip)
 
         i = 0
         try:
             for vulnerability in self._start_scan(
-                host_ip=message.host_ip,
-                host_name=message.host_name,
+                host_ip=host_ip,
+                host_name=host_name,
                 installed_packages=installed_packages,
                 package_advisories=package_advisories,
             ):
                 i += 1
-                self._publish_result(message.scan_id, vulnerability)
+                self._publish_result(scan_id, vulnerability)
 
             logger.info("Total number of vulnerable packages -> %d", i)
 
-            self._finish_host(message.scan_id, message.host_ip)
+            self._finish_host(scan_id, host_ip)
 
         except AdvisoriesLoadingError as e:
             logger.error(
                 "Scan for %s %s with %s could not be started. Error was %s",
-                message.host_ip,
-                message.host_name or "",
-                message.os_release,
+                host_ip,
+                host_name or "",
+                os_release,
                 e,
             )

--- a/poetry.lock
+++ b/poetry.lock
@@ -50,6 +50,22 @@ autohooks = ">=2.2.0"
 pylint = ">=2.8.3,<3.0.0"
 
 [[package]]
+name = "bcrypt"
+version = "3.2.0"
+description = "Modern password hashing for your software and your servers"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+cffi = ">=1.1"
+six = ">=1.4.1"
+
+[package.extras]
+tests = ["pytest (>=3.2.1,!=3.3.0)"]
+typecheck = ["mypy"]
+
+[[package]]
 name = "black"
 version = "21.12b0"
 description = "The uncompromising code formatter."
@@ -85,8 +101,19 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "cffi"
+version = "1.15.0"
+description = "Foreign Function Interface for Python calling C code."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pycparser = "*"
+
+[[package]]
 name = "charset-normalizer"
-version = "2.0.10"
+version = "2.0.11"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 category = "dev"
 optional = false
@@ -125,6 +152,25 @@ python-versions = "*"
 
 [package.dependencies]
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[[package]]
+name = "cryptography"
+version = "36.0.1"
+description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+cffi = ">=1.12"
+
+[package.extras]
+docs = ["sphinx (>=1.6.5,!=1.8.0,!=3.1.0,!=3.1.1)", "sphinx-rtd-theme"]
+docstest = ["pyenchant (>=1.6.11)", "twine (>=1.12.0)", "sphinxcontrib-spelling (>=4.0.1)"]
+pep8test = ["black", "flake8", "flake8-import-order", "pep8-naming"]
+sdist = ["setuptools_rust (>=0.11.4)"]
+ssh = ["bcrypt (>=3.1.5)"]
+test = ["pytest (>=6.2.0)", "pytest-cov", "pytest-subtests", "pytest-xdist", "pretend", "iso8601", "pytz", "hypothesis (>=1.11.4,!=3.79.2)"]
 
 [[package]]
 name = "idna"
@@ -212,6 +258,25 @@ python-versions = "*"
 proxy = ["pysocks"]
 
 [[package]]
+name = "paramiko"
+version = "2.9.2"
+description = "SSH2 protocol library"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+bcrypt = ">=3.1.3"
+cryptography = ">=2.5"
+pynacl = ">=1.0.1"
+
+[package.extras]
+all = ["pyasn1 (>=0.1.7)", "pynacl (>=1.0.1)", "bcrypt (>=3.1.3)", "invoke (>=1.3)", "gssapi (>=1.4.1)", "pywin32 (>=2.1.8)"]
+ed25519 = ["pynacl (>=1.0.1)", "bcrypt (>=3.1.3)"]
+gssapi = ["pyasn1 (>=0.1.7)", "gssapi (>=1.4.1)", "pywin32 (>=2.1.8)"]
+invoke = ["invoke (>=1.3)"]
+
+[[package]]
 name = "pathspec"
 version = "0.9.0"
 description = "Utility library for gitignore style pattern matching of file paths."
@@ -233,7 +298,7 @@ test = ["appdirs (==1.4.4)", "pytest (>=6)", "pytest-cov (>=2.7)", "pytest-mock 
 
 [[package]]
 name = "pontos"
-version = "22.1.1"
+version = "22.1.3"
 description = "Common utilities and tools maintained by Greenbone Networks"
 category = "dev"
 optional = false
@@ -257,6 +322,14 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 test = ["ipaddress", "mock", "unittest2", "enum34", "pywin32", "wmi"]
 
 [[package]]
+name = "pycparser"
+version = "2.21"
+description = "C parser in Python"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
 name = "pylint"
 version = "2.12.2"
 description = "python code static checker"
@@ -272,6 +345,21 @@ mccabe = ">=0.6,<0.7"
 platformdirs = ">=2.2.0"
 toml = ">=0.9.2"
 typing-extensions = {version = ">=3.10.0", markers = "python_version < \"3.10\""}
+
+[[package]]
+name = "pynacl"
+version = "1.5.0"
+description = "Python binding to the Networking and Cryptography (NaCl) library"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+cffi = ">=1.4.1"
+
+[package.extras]
+docs = ["sphinx (>=1.6.5)", "sphinx-rtd-theme"]
+tests = ["pytest (>=3.2.1,!=3.3.0)", "hypothesis (>=3.27.0)"]
 
 [[package]]
 name = "pyparsing"
@@ -323,7 +411,7 @@ dev = ["build", "pytest", "pytest-timeout"]
 
 [[package]]
 name = "sentry-sdk"
-version = "1.5.3"
+version = "1.5.4"
 description = "Python client for Sentry (https://sentry.io)"
 category = "main"
 optional = true
@@ -352,6 +440,14 @@ sqlalchemy = ["sqlalchemy (>=1.2)"]
 tornado = ["tornado (>=5)"]
 
 [[package]]
+name = "six"
+version = "1.16.0"
+description = "Python 2 and 3 compatibility utilities"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
 name = "toml"
 version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
@@ -369,7 +465,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "tomlkit"
-version = "0.8.0"
+version = "0.9.0"
 description = "Style preserving TOML library"
 category = "dev"
 optional = false
@@ -430,7 +526,7 @@ sentry = ["sentry-sdk"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "f13c4b78efe4aea0b9db71fbf5bb39f69b99860ca6b74d1c3e4eb159bfeec0be"
+content-hash = "ba51af7c045fe6c723748691b8bf1ea68d73b79429b17c920c650c8efdff4278"
 
 [metadata.files]
 astroid = [
@@ -449,6 +545,15 @@ autohooks-plugin-pylint = [
     {file = "autohooks-plugin-pylint-21.6.0.tar.gz", hash = "sha256:6f1a486f19c8012618fecd9eaa985f5da3ef5c954b32d823323439547b947302"},
     {file = "autohooks_plugin_pylint-21.6.0-py3-none-any.whl", hash = "sha256:0d6ab34739d4c494012aa1647c02e6a4fb9474e4050432ee82f378fcd05c70e4"},
 ]
+bcrypt = [
+    {file = "bcrypt-3.2.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:c95d4cbebffafcdd28bd28bb4e25b31c50f6da605c81ffd9ad8a3d1b2ab7b1b6"},
+    {file = "bcrypt-3.2.0-cp36-abi3-manylinux1_x86_64.whl", hash = "sha256:63d4e3ff96188e5898779b6057878fecf3f11cfe6ec3b313ea09955d587ec7a7"},
+    {file = "bcrypt-3.2.0-cp36-abi3-manylinux2010_x86_64.whl", hash = "sha256:cd1ea2ff3038509ea95f687256c46b79f5fc382ad0aa3664d200047546d511d1"},
+    {file = "bcrypt-3.2.0-cp36-abi3-manylinux2014_aarch64.whl", hash = "sha256:cdcdcb3972027f83fe24a48b1e90ea4b584d35f1cc279d76de6fc4b13376239d"},
+    {file = "bcrypt-3.2.0-cp36-abi3-win32.whl", hash = "sha256:a67fb841b35c28a59cebed05fbd3e80eea26e6d75851f0574a9273c80f3e9b55"},
+    {file = "bcrypt-3.2.0-cp36-abi3-win_amd64.whl", hash = "sha256:81fec756feff5b6818ea7ab031205e1d323d8943d237303baca2c5f9c7846f34"},
+    {file = "bcrypt-3.2.0.tar.gz", hash = "sha256:5b93c1726e50a93a033c36e5ca7fdcd29a5c7395af50a6892f5d9e7c6cfbfb29"},
+]
 black = [
     {file = "black-21.12b0-py3-none-any.whl", hash = "sha256:a615e69ae185e08fdd73e4715e260e2479c861b5740057fde6e8b4e3b7dd589f"},
     {file = "black-21.12b0.tar.gz", hash = "sha256:77b80f693a569e2e527958459634f18df9b0ba2625ba4e0c2d5da5be42e6f2b3"},
@@ -457,9 +562,61 @@ certifi = [
     {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
     {file = "certifi-2021.10.8.tar.gz", hash = "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872"},
 ]
+cffi = [
+    {file = "cffi-1.15.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:c2502a1a03b6312837279c8c1bd3ebedf6c12c4228ddbad40912d671ccc8a962"},
+    {file = "cffi-1.15.0-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:23cfe892bd5dd8941608f93348c0737e369e51c100d03718f108bf1add7bd6d0"},
+    {file = "cffi-1.15.0-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:41d45de54cd277a7878919867c0f08b0cf817605e4eb94093e7516505d3c8d14"},
+    {file = "cffi-1.15.0-cp27-cp27m-win32.whl", hash = "sha256:4a306fa632e8f0928956a41fa8e1d6243c71e7eb59ffbd165fc0b41e316b2474"},
+    {file = "cffi-1.15.0-cp27-cp27m-win_amd64.whl", hash = "sha256:e7022a66d9b55e93e1a845d8c9eba2a1bebd4966cd8bfc25d9cd07d515b33fa6"},
+    {file = "cffi-1.15.0-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:14cd121ea63ecdae71efa69c15c5543a4b5fbcd0bbe2aad864baca0063cecf27"},
+    {file = "cffi-1.15.0-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:d4d692a89c5cf08a8557fdeb329b82e7bf609aadfaed6c0d79f5a449a3c7c023"},
+    {file = "cffi-1.15.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0104fb5ae2391d46a4cb082abdd5c69ea4eab79d8d44eaaf79f1b1fd806ee4c2"},
+    {file = "cffi-1.15.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:91ec59c33514b7c7559a6acda53bbfe1b283949c34fe7440bcf917f96ac0723e"},
+    {file = "cffi-1.15.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:f5c7150ad32ba43a07c4479f40241756145a1f03b43480e058cfd862bf5041c7"},
+    {file = "cffi-1.15.0-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:00c878c90cb53ccfaae6b8bc18ad05d2036553e6d9d1d9dbcf323bbe83854ca3"},
+    {file = "cffi-1.15.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:abb9a20a72ac4e0fdb50dae135ba5e77880518e742077ced47eb1499e29a443c"},
+    {file = "cffi-1.15.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a5263e363c27b653a90078143adb3d076c1a748ec9ecc78ea2fb916f9b861962"},
+    {file = "cffi-1.15.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f54a64f8b0c8ff0b64d18aa76675262e1700f3995182267998c31ae974fbc382"},
+    {file = "cffi-1.15.0-cp310-cp310-win32.whl", hash = "sha256:c21c9e3896c23007803a875460fb786118f0cdd4434359577ea25eb556e34c55"},
+    {file = "cffi-1.15.0-cp310-cp310-win_amd64.whl", hash = "sha256:5e069f72d497312b24fcc02073d70cb989045d1c91cbd53979366077959933e0"},
+    {file = "cffi-1.15.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:64d4ec9f448dfe041705426000cc13e34e6e5bb13736e9fd62e34a0b0c41566e"},
+    {file = "cffi-1.15.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2756c88cbb94231c7a147402476be2c4df2f6078099a6f4a480d239a8817ae39"},
+    {file = "cffi-1.15.0-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3b96a311ac60a3f6be21d2572e46ce67f09abcf4d09344c49274eb9e0bf345fc"},
+    {file = "cffi-1.15.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:75e4024375654472cc27e91cbe9eaa08567f7fbdf822638be2814ce059f58032"},
+    {file = "cffi-1.15.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:59888172256cac5629e60e72e86598027aca6bf01fa2465bdb676d37636573e8"},
+    {file = "cffi-1.15.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:27c219baf94952ae9d50ec19651a687b826792055353d07648a5695413e0c605"},
+    {file = "cffi-1.15.0-cp36-cp36m-win32.whl", hash = "sha256:4958391dbd6249d7ad855b9ca88fae690783a6be9e86df65865058ed81fc860e"},
+    {file = "cffi-1.15.0-cp36-cp36m-win_amd64.whl", hash = "sha256:f6f824dc3bce0edab5f427efcfb1d63ee75b6fcb7282900ccaf925be84efb0fc"},
+    {file = "cffi-1.15.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:06c48159c1abed75c2e721b1715c379fa3200c7784271b3c46df01383b593636"},
+    {file = "cffi-1.15.0-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:c2051981a968d7de9dd2d7b87bcb9c939c74a34626a6e2f8181455dd49ed69e4"},
+    {file = "cffi-1.15.0-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:fd8a250edc26254fe5b33be00402e6d287f562b6a5b2152dec302fa15bb3e997"},
+    {file = "cffi-1.15.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:91d77d2a782be4274da750752bb1650a97bfd8f291022b379bb8e01c66b4e96b"},
+    {file = "cffi-1.15.0-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:45db3a33139e9c8f7c09234b5784a5e33d31fd6907800b316decad50af323ff2"},
+    {file = "cffi-1.15.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:263cc3d821c4ab2213cbe8cd8b355a7f72a8324577dc865ef98487c1aeee2bc7"},
+    {file = "cffi-1.15.0-cp37-cp37m-win32.whl", hash = "sha256:17771976e82e9f94976180f76468546834d22a7cc404b17c22df2a2c81db0c66"},
+    {file = "cffi-1.15.0-cp37-cp37m-win_amd64.whl", hash = "sha256:3415c89f9204ee60cd09b235810be700e993e343a408693e80ce7f6a40108029"},
+    {file = "cffi-1.15.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:4238e6dab5d6a8ba812de994bbb0a79bddbdf80994e4ce802b6f6f3142fcc880"},
+    {file = "cffi-1.15.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0808014eb713677ec1292301ea4c81ad277b6cdf2fdd90fd540af98c0b101d20"},
+    {file = "cffi-1.15.0-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:57e9ac9ccc3101fac9d6014fba037473e4358ef4e89f8e181f8951a2c0162024"},
+    {file = "cffi-1.15.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b6c2ea03845c9f501ed1313e78de148cd3f6cad741a75d43a29b43da27f2e1e"},
+    {file = "cffi-1.15.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:10dffb601ccfb65262a27233ac273d552ddc4d8ae1bf93b21c94b8511bffe728"},
+    {file = "cffi-1.15.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:786902fb9ba7433aae840e0ed609f45c7bcd4e225ebb9c753aa39725bb3e6ad6"},
+    {file = "cffi-1.15.0-cp38-cp38-win32.whl", hash = "sha256:da5db4e883f1ce37f55c667e5c0de439df76ac4cb55964655906306918e7363c"},
+    {file = "cffi-1.15.0-cp38-cp38-win_amd64.whl", hash = "sha256:181dee03b1170ff1969489acf1c26533710231c58f95534e3edac87fff06c443"},
+    {file = "cffi-1.15.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:45e8636704eacc432a206ac7345a5d3d2c62d95a507ec70d62f23cd91770482a"},
+    {file = "cffi-1.15.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:31fb708d9d7c3f49a60f04cf5b119aeefe5644daba1cd2a0fe389b674fd1de37"},
+    {file = "cffi-1.15.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:6dc2737a3674b3e344847c8686cf29e500584ccad76204efea14f451d4cc669a"},
+    {file = "cffi-1.15.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:74fdfdbfdc48d3f47148976f49fab3251e550a8720bebc99bf1483f5bfb5db3e"},
+    {file = "cffi-1.15.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffaa5c925128e29efbde7301d8ecaf35c8c60ffbcd6a1ffd3a552177c8e5e796"},
+    {file = "cffi-1.15.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f7d084648d77af029acb79a0ff49a0ad7e9d09057a9bf46596dac9514dc07df"},
+    {file = "cffi-1.15.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ef1f279350da2c586a69d32fc8733092fd32cc8ac95139a00377841f59a3f8d8"},
+    {file = "cffi-1.15.0-cp39-cp39-win32.whl", hash = "sha256:2a23af14f408d53d5e6cd4e3d9a24ff9e05906ad574822a10563efcef137979a"},
+    {file = "cffi-1.15.0-cp39-cp39-win_amd64.whl", hash = "sha256:3773c4d81e6e818df2efbc7dd77325ca0dcb688116050fb2b3011218eda36139"},
+    {file = "cffi-1.15.0.tar.gz", hash = "sha256:920f0d66a896c2d99f0adbb391f990a84091179542c205fa53ce5787aff87954"},
+]
 charset-normalizer = [
-    {file = "charset-normalizer-2.0.10.tar.gz", hash = "sha256:876d180e9d7432c5d1dfd4c5d26b72f099d503e8fcc0feb7532c9289be60fcbd"},
-    {file = "charset_normalizer-2.0.10-py3-none-any.whl", hash = "sha256:cb957888737fc0bbcd78e3df769addb41fd1ff8cf950dc9e7ad7793f1bf44455"},
+    {file = "charset-normalizer-2.0.11.tar.gz", hash = "sha256:98398a9d69ee80548c762ba991a4728bfc3836768ed226b3945908d1a688371c"},
+    {file = "charset_normalizer-2.0.11-py3-none-any.whl", hash = "sha256:2842d8f5e82a1f6aa437380934d5e1cd4fcf2003b06fed6940769c164a480a45"},
 ]
 click = [
     {file = "click-8.0.3-py3-none-any.whl", hash = "sha256:353f466495adaeb40b6b5f592f9f91cb22372351c84caeb068132442a4518ef3"},
@@ -472,6 +629,28 @@ colorama = [
 colorful = [
     {file = "colorful-0.5.4-py2.py3-none-any.whl", hash = "sha256:8d264b52a39aae4c0ba3e2a46afbaec81b0559a99be0d2cfe2aba4cf94531348"},
     {file = "colorful-0.5.4.tar.gz", hash = "sha256:86848ad4e2eda60cd2519d8698945d22f6f6551e23e95f3f14dfbb60997807ea"},
+]
+cryptography = [
+    {file = "cryptography-36.0.1-cp36-abi3-macosx_10_10_universal2.whl", hash = "sha256:73bc2d3f2444bcfeac67dd130ff2ea598ea5f20b40e36d19821b4df8c9c5037b"},
+    {file = "cryptography-36.0.1-cp36-abi3-macosx_10_10_x86_64.whl", hash = "sha256:2d87cdcb378d3cfed944dac30596da1968f88fb96d7fc34fdae30a99054b2e31"},
+    {file = "cryptography-36.0.1-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:74d6c7e80609c0f4c2434b97b80c7f8fdfaa072ca4baab7e239a15d6d70ed73a"},
+    {file = "cryptography-36.0.1-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:6c0c021f35b421ebf5976abf2daacc47e235f8b6082d3396a2fe3ccd537ab173"},
+    {file = "cryptography-36.0.1-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d59a9d55027a8b88fd9fd2826c4392bd487d74bf628bb9d39beecc62a644c12"},
+    {file = "cryptography-36.0.1-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0a817b961b46894c5ca8a66b599c745b9a3d9f822725221f0e0fe49dc043a3a3"},
+    {file = "cryptography-36.0.1-cp36-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:94ae132f0e40fe48f310bba63f477f14a43116f05ddb69d6fa31e93f05848ae2"},
+    {file = "cryptography-36.0.1-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:7be0eec337359c155df191d6ae00a5e8bbb63933883f4f5dffc439dac5348c3f"},
+    {file = "cryptography-36.0.1-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:e0344c14c9cb89e76eb6a060e67980c9e35b3f36691e15e1b7a9e58a0a6c6dc3"},
+    {file = "cryptography-36.0.1-cp36-abi3-win32.whl", hash = "sha256:4caa4b893d8fad33cf1964d3e51842cd78ba87401ab1d2e44556826df849a8ca"},
+    {file = "cryptography-36.0.1-cp36-abi3-win_amd64.whl", hash = "sha256:391432971a66cfaf94b21c24ab465a4cc3e8bf4a939c1ca5c3e3a6e0abebdbcf"},
+    {file = "cryptography-36.0.1-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:bb5829d027ff82aa872d76158919045a7c1e91fbf241aec32cb07956e9ebd3c9"},
+    {file = "cryptography-36.0.1-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ebc15b1c22e55c4d5566e3ca4db8689470a0ca2babef8e3a9ee057a8b82ce4b1"},
+    {file = "cryptography-36.0.1-pp37-pypy37_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:596f3cd67e1b950bc372c33f1a28a0692080625592ea6392987dba7f09f17a94"},
+    {file = "cryptography-36.0.1-pp38-pypy38_pp73-macosx_10_10_x86_64.whl", hash = "sha256:30ee1eb3ebe1644d1c3f183d115a8c04e4e603ed6ce8e394ed39eea4a98469ac"},
+    {file = "cryptography-36.0.1-pp38-pypy38_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ec63da4e7e4a5f924b90af42eddf20b698a70e58d86a72d943857c4c6045b3ee"},
+    {file = "cryptography-36.0.1-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca238ceb7ba0bdf6ce88c1b74a87bffcee5afbfa1e41e173b1ceb095b39add46"},
+    {file = "cryptography-36.0.1-pp38-pypy38_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:ca28641954f767f9822c24e927ad894d45d5a1e501767599647259cbf030b903"},
+    {file = "cryptography-36.0.1-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:39bdf8e70eee6b1c7b289ec6e5d84d49a6bfa11f8b8646b5b3dfe41219153316"},
+    {file = "cryptography-36.0.1.tar.gz", hash = "sha256:53e5c1dc3d7a953de055d77bef2ff607ceef7a2aac0353b5d630ab67f7423638"},
 ]
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
@@ -539,6 +718,10 @@ packaging = [
 paho-mqtt = [
     {file = "paho-mqtt-1.6.1.tar.gz", hash = "sha256:2a8291c81623aec00372b5a85558a372c747cbca8e9934dfe218638b8eefc26f"},
 ]
+paramiko = [
+    {file = "paramiko-2.9.2-py2.py3-none-any.whl", hash = "sha256:04097dbd96871691cdb34c13db1883066b8a13a0df2afd4cb0a92221f51c2603"},
+    {file = "paramiko-2.9.2.tar.gz", hash = "sha256:944a9e5dbdd413ab6c7951ea46b0ab40713235a9c4c5ca81cfe45c6f14fa677b"},
+]
 pathspec = [
     {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
     {file = "pathspec-0.9.0.tar.gz", hash = "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"},
@@ -548,8 +731,8 @@ platformdirs = [
     {file = "platformdirs-2.4.1.tar.gz", hash = "sha256:440633ddfebcc36264232365d7840a970e75e1018d15b4327d11f91909045fda"},
 ]
 pontos = [
-    {file = "pontos-22.1.1-py3-none-any.whl", hash = "sha256:c60f603933f2b6ce4123a88919cc188e56b2378674a2a203bb570591aa9af6a1"},
-    {file = "pontos-22.1.1.tar.gz", hash = "sha256:d0cff0d95b22343b37aced70d87abbcea77826c84ac09206aea1c23d15d31bfb"},
+    {file = "pontos-22.1.3-py3-none-any.whl", hash = "sha256:dad4eed7bfdfaf82b01d35a49cc45c393bad2ba16c579da9c99193674a4735eb"},
+    {file = "pontos-22.1.3.tar.gz", hash = "sha256:8584d58a36b78bcf7d1d4408018b7d019e590ce01400a64ed3845793369ca45f"},
 ]
 psutil = [
     {file = "psutil-5.9.0-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:55ce319452e3d139e25d6c3f85a1acf12d1607ddedea5e35fb47a552c051161b"},
@@ -585,9 +768,25 @@ psutil = [
     {file = "psutil-5.9.0-cp39-cp39-win_amd64.whl", hash = "sha256:7d190ee2eaef7831163f254dc58f6d2e2a22e27382b936aab51c835fc080c3d3"},
     {file = "psutil-5.9.0.tar.gz", hash = "sha256:869842dbd66bb80c3217158e629d6fceaecc3a3166d3d1faee515b05dd26ca25"},
 ]
+pycparser = [
+    {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
+    {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
+]
 pylint = [
     {file = "pylint-2.12.2-py3-none-any.whl", hash = "sha256:daabda3f7ed9d1c60f52d563b1b854632fd90035bcf01443e234d3dc794e3b74"},
     {file = "pylint-2.12.2.tar.gz", hash = "sha256:9d945a73640e1fec07ee34b42f5669b770c759acd536ec7b16d7e4b87a9c9ff9"},
+]
+pynacl = [
+    {file = "PyNaCl-1.5.0-cp36-abi3-macosx_10_10_universal2.whl", hash = "sha256:401002a4aaa07c9414132aaed7f6836ff98f59277a234704ff66878c2ee4a0d1"},
+    {file = "PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:52cb72a79269189d4e0dc537556f4740f7f0a9ec41c1322598799b0bdad4ef92"},
+    {file = "PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a36d4a9dda1f19ce6e03c9a784a2921a4b726b02e1c736600ca9c22029474394"},
+    {file = "PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:0c84947a22519e013607c9be43706dd42513f9e6ae5d39d3613ca1e142fba44d"},
+    {file = "PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:06b8f6fa7f5de8d5d2f7573fe8c863c051225a27b61e6860fd047b1775807858"},
+    {file = "PyNaCl-1.5.0-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:a422368fc821589c228f4c49438a368831cb5bbc0eab5ebe1d7fac9dded6567b"},
+    {file = "PyNaCl-1.5.0-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:61f642bf2378713e2c2e1de73444a3778e5f0a38be6fee0fe532fe30060282ff"},
+    {file = "PyNaCl-1.5.0-cp36-abi3-win32.whl", hash = "sha256:e46dae94e34b085175f8abb3b0aaa7da40767865ac82c928eeb9e57e1ea8a543"},
+    {file = "PyNaCl-1.5.0-cp36-abi3-win_amd64.whl", hash = "sha256:20f42270d27e1b6a29f54032090b972d97f0a1b0948cc52392041ef7831fee93"},
+    {file = "PyNaCl-1.5.0.tar.gz", hash = "sha256:8ac7448f09ab85811607bdd21ec2464495ac8b7c66d146bf545b0f08fb9220ba"},
 ]
 pyparsing = [
     {file = "pyparsing-3.0.7-py3-none-any.whl", hash = "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"},
@@ -606,8 +805,12 @@ rope = [
     {file = "rope-0.22.0.tar.gz", hash = "sha256:b00fbc064a26fc62d7220578a27fd639b2fad57213663cc396c137e92d73f10f"},
 ]
 sentry-sdk = [
-    {file = "sentry-sdk-1.5.3.tar.gz", hash = "sha256:141da032f0fa4c56f9af6b361fda57360af1789576285bd1944561f9c274f9c0"},
-    {file = "sentry_sdk-1.5.3-py2.py3-none-any.whl", hash = "sha256:9aeff2a47f4038460296b920bf4d269284e8454e1c67547ee002ccafd9c2442b"},
+    {file = "sentry-sdk-1.5.4.tar.gz", hash = "sha256:f7e54567937ebcbe938c4df1075ec891587faeb7c74184b88cf2894e47c86116"},
+    {file = "sentry_sdk-1.5.4-py2.py3-none-any.whl", hash = "sha256:4fc7960a82c95d906a0514cf4d9aacba1743eb9863a5b7c2a01c525a7d9b21e6"},
+]
+six = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
 ]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
@@ -618,8 +821,8 @@ tomli = [
     {file = "tomli-1.2.3.tar.gz", hash = "sha256:05b6166bff487dc068d322585c7ea4ef78deed501cc124060e0f238e89a9231f"},
 ]
 tomlkit = [
-    {file = "tomlkit-0.8.0-py3-none-any.whl", hash = "sha256:b824e3466f1d475b2b5f1c392954c6cb7ea04d64354ff7300dc7c14257dc85db"},
-    {file = "tomlkit-0.8.0.tar.gz", hash = "sha256:29e84a855712dfe0e88a48f6d05c21118dbafb283bb2eed614d46f80deb8e9a1"},
+    {file = "tomlkit-0.9.0-py3-none-any.whl", hash = "sha256:c1b0fc73abd4f1e77c29ea4061ca0f2e11cbfb77342e17df3d3fdd496fc3f899"},
+    {file = "tomlkit-0.9.0.tar.gz", hash = "sha256:5a83672c565f78f5fc8f1e44e5f2726446cc6b765113efd21d03e9331747d9ab"},
 ]
 typed-ast = [
     {file = "typed_ast-1.5.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:183b183b7771a508395d2cbffd6db67d6ad52958a5fdc99f450d954003900266"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ sentry-sdk = {version = "^1.5.3", optional = true}
 python-gnupg = "^0.4.8"
 tomli = "<2.0.0"
 packaging = "<21.3"
+paramiko = "^2.9.2"
 
 [tool.poetry.extras]
 sentry = ["sentry-sdk"]


### PR DESCRIPTION
**What**:
Add internal gather package list to remove dependency to openvas. A scan can now be started either via the package list or via ssh credentials. Currently only username + pw is supported.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Remove dependency to openvas

<!-- Why are these changes necessary? -->

**How**:
Start notus-scanner and send message via MQTT:
```json
{
  "scan_id": "foo",
  "host_ip": "127.0.0.1",
  "host_name": "localhost",
  "ssh_login": "user",
  "ssh_password": "pw",
  "ssh_port": 22,
  "message_id": "74b29d1e-3a41-4dda-8f15-99276985bf6a",
  "group_id": "74b29d1e-3a41-4dda-8f15-99276985bf6a",
  "created": 0,
  "message_type": "scan.start"
}
```
The same number of vulnerabilities should be shown, as in a normal scan or when only gather-package-list.nasl is run.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/notus-scanner/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
