### PR TITLE
Change: pack vulnerabilities from same OID in single result

### DIFF
--- a/notus/scanner/models/vulnerability.py
+++ b/notus/scanner/models/vulnerability.py
@@ -16,6 +16,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 from dataclasses import dataclass
+from typing import Dict
 
 from ..models.advisory import Advisory
 from .packages.package import Package
@@ -27,6 +28,22 @@ class PackageVulnerability:
 
     host_ip: str
     host_name: str
-    package: Package
-    fixed_package: Package
+    packages: Dict[Package, Package]
     advisory: Advisory
+
+    def __init__(
+        self,
+        host_ip: str,
+        host_name: str,
+        package: Package,
+        fixed_package: Package,
+        advisory: Advisory,
+    ) -> None:
+        self.host_ip = host_ip
+        self.host_name = host_name
+        self.packages = {}
+        self.packages[package] = fixed_package
+        self.advisory = advisory
+
+    def add_package(self, package: Package, fixed_package: Package):
+        self.packages[package] = fixed_package

--- a/tests/models/test_vulnerability.py
+++ b/tests/models/test_vulnerability.py
@@ -67,13 +67,14 @@ class PackageVulnerabilityTestCase(TestCase):
         advisory = package_vulnerability.advisory
         self.assertEqual(advisory.oid, "1.2.3.4.5")
 
-        package = package_vulnerability.package
+        package, fixed_package = next(
+            iter(package_vulnerability.packages.items())
+        )
         self.assertEqual(package.name, "foo-bar")
         self.assertEqual(package.version, "1.2.3")  # pylint: disable=no-member
         self.assertEqual(package.release, "4")  # pylint: disable=no-member
         self.assertEqual(package.full_name, "foo-bar-1.2.3-4.x86_64")
 
-        fixed_package = package_vulnerability.fixed_package
         self.assertEqual(fixed_package.name, "foo-bar")
         self.assertEqual(
             fixed_package.version, "1.2.4"  # pylint: disable=no-member

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -38,9 +38,10 @@ class FakePublisher(Publisher):
     def publish(self, message: Message) -> None:
         serialized = message.serialize()
         values = str(serialized.get("value", "")).split("\n")
-        if len(values) > 2:
-            installed = values[1][len("Installed version: ") :].strip()
-            self.results.append(installed)
+        for value in values:
+            if value.find("Installed version:") >= 0:
+                installed = value[len("Installed version: ") :].strip()
+                self.results.append(installed)
 
 
 class VerifierTestCase(unittest.TestCase):
@@ -80,7 +81,7 @@ class VerifierTestCase(unittest.TestCase):
             for fps in fixed_packages
             for fp in fps
         )
-        # cases that should not appear in resul
+        # cases that should not appear in result
         not_in = []
         # cases that should appear in result
         is_in = []


### PR DESCRIPTION
**What**:
Combine multiple package vulnerabilities which belong to the same OID into a single result.
SC-504

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
The notus-scanner changed the behavior in which results are presented to the client. This lead to confusion, as multiple results with the same name showed up in the client. This could confuse users, as they seem like duplicated results. With this PR results are presented again as they should.

<!-- Why are these changes necessary? -->

**How**:
Run a Full and Fast scan to see if results are presented as they should.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/notus-scanner/blob/master/CHANGELOG.md) Entry
- [x] Documentation
