### PR TITLE
Fix: false positive for equal deb versions

### DIFF
--- a/notus/scanner/models/packages/deb.py
+++ b/notus/scanner/models/packages/deb.py
@@ -65,6 +65,7 @@ class DEBPackage(Package):
         if not full_name:
             return None
 
+        full_name = full_name.strip()
         # Try to get data with
         try:
             name, epoch, upstream_version, debian_revision = _deb_compile.match(
@@ -104,6 +105,8 @@ class DEBPackage(Package):
     def from_name_and_full_version(name: str, full_version: str):
         if not name or not full_version:
             return None
+        name = name.strip()
+        full_version = full_version.strip()
         try:
             (
                 epoch,

--- a/notus/scanner/models/packages/rpm.py
+++ b/notus/scanner/models/packages/rpm.py
@@ -60,12 +60,14 @@ class RPMPackage(Package):
         if not full_name:
             return None
 
+        full_name = full_name.strip()
+
         try:
             name, version, release, architecture = _rpm_compile.match(
                 full_name
             ).groups()
             try:
-                arch = Architecture(architecture.strip())
+                arch = Architecture(architecture)
             except ValueError:
                 arch = Architecture.UNKNOWN
         except AttributeError:
@@ -94,13 +96,16 @@ class RPMPackage(Package):
         if not name or not full_version:
             return None
 
+        name = name.strip()
+        full_version = full_version.strip()
+
         version_match = _rpm_compile_version.match(full_version)
         if not version_match:
             return None
         version, release, architecture = version_match.groups()
 
         try:
-            arch = Architecture(architecture.strip())
+            arch = Architecture(architecture)
         except ValueError:
             arch = Architecture.UNKNOWN
 


### PR DESCRIPTION
**What**:
Remove white spaces before parsing package versions.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
openvas is sending an invisible `\r` character at the end of each package. This lead to a false positive comparison if installed and fixed version were equal.

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/notus-scanner/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
