### PR TITLE
Use an entrypoint script to switch to notus user

### DIFF
--- a/.docker/entrypoint.sh
+++ b/.docker/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec gosu notus "$@"

--- a/.docker/notus-scanner.Dockerfile
+++ b/.docker/notus-scanner.Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /notus
 
 RUN apt-get update && \
     apt-get install --no-install-recommends --no-install-suggests -y \
+    gosu \
     gpg \
     gpg-agent \
     python3 \
@@ -22,14 +23,15 @@ RUN addgroup --gid 1001 --system notus && \
     adduser --no-create-home --shell /bin/false --disabled-password --uid 1001 --system --group notus
 
 COPY dist/* /notus
+COPY .docker/entrypoint.sh /usr/local/bin/entrypoint
 
 RUN python3 -m pip install /notus/*
 
 RUN apt-get purge -y gcc python3-dev && apt-get autoremove -y
 
-RUN chown notus:notus /notus
+RUN chown notus:notus /notus && \
+    chmod 755 /usr/local/bin/entrypoint
 
-USER notus
+ENTRYPOINT [ "/usr/local/bin/entrypoint" ]
 
-ENTRYPOINT [ "notus-scanner" ]
-CMD ["-f", "--pid-file=/notus/notus-scanner.pid", "-b", "broker"]
+CMD ["notus-scanner", "-f", "--pid-file=/notus/notus-scanner.pid", "-b", "broker"]

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-.docker/
 .git/
 .github/
 .vscode/


### PR DESCRIPTION
**What**:

Use an entrypoint script to switch to notus user

**Why**:

By using an entrypoint script with gosu to switch to the notus user for
running the notus-scanner it allows for becoming root and changing
the container more easily.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/notus-scanner/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
