### PR TITLE
Create and set directory permissions for feed content

### DIFF
--- a/.docker/notus-scanner.Dockerfile
+++ b/.docker/notus-scanner.Dockerfile
@@ -29,7 +29,8 @@ RUN python3 -m pip install /notus/*
 
 RUN apt-get purge -y gcc python3-dev && apt-get autoremove -y
 
-RUN chown notus:notus /notus && \
+RUN mkdir -p /var/lib/notus && \
+    chown -R notus:notus /notus /var/lib/notus && \
     chmod 755 /usr/local/bin/entrypoint
 
 ENTRYPOINT [ "/usr/local/bin/entrypoint" ]


### PR DESCRIPTION
**What**:

The container assumes the default /var/lib/notus directory for the feed
content. This directory must have the correct access rights for being
able to sync the notus files from the feed.

**Why**:

Can't sync the feed when /var/lib/notus is owned by root.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/notus-scanner/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
