### PR TITLE
Fix: ConnectionRefusedError on startup when no broker is running

### DIFF
--- a/notus/scanner/daemon.py
+++ b/notus/scanner/daemon.py
@@ -111,19 +111,19 @@ def run_daemon(
     loader = JSONAdvisoriesLoader(
         advisories_directory_path=products_directory_path, verify=verifier
     )
+    client = MQTTClient(
+        mqtt_broker_address=mqtt_broker_address,
+        mqtt_broker_port=mqtt_broker_port,
+    )
+    daemon: MQTTDaemon
     try:
-        client = MQTTClient(
-            mqtt_broker_address=mqtt_broker_address,
-            mqtt_broker_port=mqtt_broker_port,
-        )
+        daemon = MQTTDaemon(client)
     except ConnectionRefusedError:
         logger.error(
             "Could not connect to MQTT broker at %s. Connection refused.",
             mqtt_broker_address,
         )
         sys.exit(1)
-
-    daemon = MQTTDaemon(client)
 
     publisher = MQTTPublisher(client)
     scanner = NotusScanner(loader=loader, publisher=publisher)


### PR DESCRIPTION
**What**:
Notus-scanner exits now with a log message instead of an exception
SC-650

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
In case no MQTT broker was running, the notus-scanner would end with a `ConnectionRefuseError` as a exception. Now a log message is printed instead

<!-- Why are these changes necessary? -->

**How**:
Start notus-scanner without having a MQTT broker running

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/notus-scanner/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
