### PR TITLE
Add: support for slackware packages

### DIFF
--- a/notus/scanner/models/packages/__init__.py
+++ b/notus/scanner/models/packages/__init__.py
@@ -20,6 +20,7 @@ from notus.scanner.models.packages.deb import DEBPackage
 from notus.scanner.models.packages.ebuild import EBuildPackage
 from notus.scanner.models.packages.package import Package, PackageType
 from notus.scanner.models.packages.rpm import RPMPackage
+from .slackware import SlackPackage
 
 
 def package_class_by_type(pt: PackageType) -> Optional[Package]:
@@ -30,5 +31,6 @@ def package_class_by_type(pt: PackageType) -> Optional[Package]:
         PackageType.RPM: RPMPackage,
         PackageType.DEB: DEBPackage,
         PackageType.EBUILD: EBuildPackage,
+        PackageType.SLACK: SlackPackage,
     }
     return switcher.get(pt)

--- a/notus/scanner/models/packages/package.py
+++ b/notus/scanner/models/packages/package.py
@@ -31,6 +31,7 @@ class PackageType(Enum):
     RPM = "rpm"
     DEB = "deb"
     EBUILD = "ebuild"
+    SLACK = "slack"
 
 
 class PackageComparision(Enum):

--- a/notus/scanner/models/packages/slackware.py
+++ b/notus/scanner/models/packages/slackware.py
@@ -1,0 +1,148 @@
+# slightly adjusted from https://github.com/ihiji/version_utils
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""
+slackware module for version_utils
+
+Contains dpkg parsing and comparison operations for version_utils.
+Public methods include:
+
+    * :any:`compare_packages`: compare two dpkg package strings, e.g.
+      ``gcc-4.4.7-16.el6.x86_64`` and ``gcc-4.4.7-17.el6.x86_64``
+    * :any:`compare_versions`: compare two dpkg version strings (the
+      bit between the dashes in an dpkg package string)
+    * :any:`package`: parse an dpkg package string to get name, epoch,
+      version, release, and architecture information. Returns as a
+      :any:`common.Package` object.
+"""
+
+import logging
+import re
+from dataclasses import dataclass
+from packaging.version import parse
+
+from .package import Architecture, Package, PackageComparision
+
+_slack_compile = re.compile(r"(..*)-(..*)-(..*)-(\d)(?:_slack(..*))?")
+_slack_compile_version = re.compile(r"(..*)-(..*)-(\d)(?:_slack(..*))?")
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SlackPackage(Package):
+    """Represents a skackware based package"""
+
+    build: str
+    target: str
+    version: str
+    arch: str
+
+    __hash__ = Package.__hash__
+
+    def _compare(self, other: "SlackPackage") -> PackageComparision:
+        if self.arch != other.arch:
+            return PackageComparision.NOT_COMPARABLE
+
+        if self.full_version == other.full_version:
+            return PackageComparision.EQUAL
+
+        a_version = parse(self.version)
+        b_version = parse(other.version)
+
+        if a_version != b_version:
+            return (
+                PackageComparision.A_NEWER
+                if a_version > b_version
+                else PackageComparision.B_NEWER
+            )
+
+        a_target = parse(self.target)
+        b_target = parse(other.target)
+
+        if a_target and b_target and a_target != b_target:
+            return (
+                PackageComparision.A_NEWER
+                if a_target > b_target
+                else PackageComparision.B_NEWER
+            )
+
+        a_build = parse(self.build)
+        b_build = parse(other.build)
+
+        if a_build != b_build:
+            return (
+                PackageComparision.A_NEWER
+                if a_build > b_build
+                else PackageComparision.B_NEWER
+            )
+
+    @staticmethod
+    def from_full_name(full_name: str):
+        if not full_name:
+            return None
+
+        full_name = full_name.strip()
+        try:
+            name, version, architecture, build, target = _slack_compile.match(
+                full_name
+            ).groups()
+        except AttributeError:
+            logger.warning(
+                "The slack package %s could not be parsed", full_name
+            )
+            return None
+
+        try:
+            arch = Architecture(architecture)
+        except ValueError:
+            arch = Architecture.UNKNOWN
+
+        full_version = f"{version}-{arch.value}-{build}"
+
+        if target:
+            full_version = f"{full_version}_slack{target}"
+
+        return SlackPackage(
+            name=name,
+            arch=arch,
+            full_name=f"{name}-{full_version}",
+            full_version=full_version,
+            build=build,
+            target=target or "",
+            version=version,
+        )
+
+    @staticmethod
+    def from_name_and_full_version(name: str, full_version: str):
+        if not name or not full_version:
+            return None
+        name = name.strip()
+        full_version = full_version.strip()
+        try:
+            version, architecture, build, target = _slack_compile_version.match(
+                full_version
+            ).groups()
+        except AttributeError:
+            logger.warning(
+                "The slack package %s could not be parsed",
+                f"{name}-{full_version}",
+            )
+            return None
+
+        try:
+            arch = Architecture(architecture)
+        except ValueError:
+            arch = Architecture.UNKNOWN
+
+        return SlackPackage(
+            name=name,
+            arch=arch,
+            full_name=f"{name}-{full_version}",
+            full_version=full_version,
+            build=build,
+            target=target or "",
+            version=version,
+        )

--- a/tests/models/packages/test_rpm.py
+++ b/tests/models/packages/test_rpm.py
@@ -158,6 +158,7 @@ class RPMPackageTestCase(TestCase):
         package = RPMPackage.from_full_name(
             "mesa-libgbm-11.2.2-2.20160614.x86_64"
         )
+
         self.assertEqual(package.arch, Architecture.X86_64)
         self.assertEqual(package.name, "mesa-libgbm")
         self.assertEqual(package.version, "11.2.2")

--- a/tests/models/packages/test_slackware.py
+++ b/tests/models/packages/test_slackware.py
@@ -1,0 +1,264 @@
+# Copyright (C) 2021-2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+from unittest import TestCase
+
+
+from notus.scanner.models.packages.package import Architecture
+from notus.scanner.models.packages.slackware import SlackPackage
+
+
+class SlackPackageTestCase(TestCase):
+    def test_compare_gt(self):
+        """packages should be comparable"""
+        package1 = SlackPackage(
+            name="foo-bar",
+            version="1.2.3",
+            build="4",
+            arch=Architecture.X86_64,
+            target="15.0",
+            full_name="foo-bar-1.2.3-x86_64-4_slack15.0",
+            full_version="1.2.3-x86_64-4_slack15.0",
+        )
+        package2 = SlackPackage(
+            name="foo-bar",
+            version="1.2.4",
+            build="4",
+            arch=Architecture.X86_64,
+            target="15.0",
+            full_name="foo-bar-1.2.4-x86_64-4_slack15.0",
+            full_version="1.2.4-x86_64-4_slack15.0",
+        )
+        self.assertGreater(package2, package1)
+
+        package2 = SlackPackage(
+            name="foo-bar",
+            version="1.2.3",
+            build="5",
+            arch=Architecture.X86_64,
+            target="15.0",
+            full_name="foo-bar-1.2.3-x86_64-5_slack15.0",
+            full_version="1.2.3-x86_64-5_slack15.0",
+        )
+        self.assertGreater(package2, package1)
+
+        package2 = SlackPackage(
+            name="foo-bar",
+            version="1.2.3",
+            build="4",
+            arch=Architecture.X86_64,
+            target="15.1",
+            full_name="foo-bar-1.2.3-x86_64-4_slack15.1",
+            full_version="1.2.3-x86_64-4_slack15.1",
+        )
+        self.assertGreater(package2, package1)
+
+    def test_compare_gt_different_architecture(self):
+        """packages of different architecture should not be comparable"""
+        package1 = SlackPackage(
+            name="foo-bar",
+            version="1.2.3",
+            build="4",
+            arch=Architecture.X86_64,
+            target="15.0",
+            full_name="foo-bar-1.2.3-x86_64-4_slack15.0",
+            full_version="1.2.3-x86_64-4_slack15.0",
+        )
+        package2 = SlackPackage(
+            name="foo-bar",
+            version="1.2.3",
+            build="4",
+            arch=Architecture.AARCH64,
+            target="15.0",
+            full_name="foo-bar-1.2.3-aarch64-4_slack15.0",
+            full_version="1.2.3-aarch64-4_slack15.0",
+        )
+        package3 = SlackPackage(
+            name="foo-bar",
+            version="1.2.4",
+            build="4",
+            arch=Architecture.AARCH64,
+            target="15.0",
+            full_name="foo-bar-1.2.4-aarch64-4_slack15.0",
+            full_version="1.2.4-aarch64-4_slack15.0",
+        )
+        package4 = SlackPackage(
+            name="foo-bar",
+            version="1.2.3",
+            build="5",
+            arch=Architecture.AARCH64,
+            target="15.0",
+            full_name="foo-bar-1.2.3-aarch64-5_slack15.0",
+            full_version="1.2.3-aarch64-5_slack15.0",
+        )
+        package5 = SlackPackage(
+            name="foo-bar",
+            version="1.2.3",
+            build="4",
+            arch=Architecture.AARCH64,
+            target="15.1",
+            full_name="foo-bar-1.2.3-aarch64-4_slack15.1",
+            full_version="1.2.3-aarch64-4_slack15.1",
+        )
+        self.assertFalse(package2 > package1)
+        self.assertFalse(package1 > package2)
+        self.assertFalse(package3 > package1)
+        self.assertFalse(package1 > package3)
+        self.assertFalse(package4 > package1)
+        self.assertFalse(package1 > package4)
+        self.assertFalse(package5 > package1)
+        self.assertFalse(package1 > package5)
+
+    def test_compare_less(self):
+        """packages should be comparable"""
+        package1 = SlackPackage(
+            name="foo-bar",
+            version="1.2.3",
+            build="4",
+            arch=Architecture.X86_64,
+            target="15.0",
+            full_name="foo-bar-1.2.3-x86_64-4_slack15.0",
+            full_version="1.2.3-x86_64-4_slack15.0",
+        )
+        package2 = SlackPackage(
+            name="foo-bar",
+            version="1.2.4",
+            build="4",
+            arch=Architecture.X86_64,
+            target="15.0",
+            full_name="foo-bar-1.2.4-x86_64-4_slack15.0",
+            full_version="1.2.4-x86_64-4_slack15.0",
+        )
+        self.assertLess(package1, package2)
+
+        package2 = SlackPackage(
+            name="foo-bar",
+            version="1.2.3",
+            build="5",
+            arch=Architecture.X86_64,
+            target="15.0",
+            full_name="foo-bar-1.2.3-x86_64-5_slack15.0",
+            full_version="1.2.3-x86_64-5_slack15.0",
+        )
+        self.assertLess(package1, package2)
+
+        package2 = SlackPackage(
+            name="foo-bar",
+            version="1.2.3",
+            build="4",
+            arch=Architecture.X86_64,
+            target="15.1",
+            full_name="foo-bar-1.2.3-x86_64-4_slack15.1",
+            full_version="1.2.3-x86_64-4_slack15.1",
+        )
+        self.assertLess(package1, package2)
+
+    def test_compare_equal(self):
+        """packages with the same data should be equal"""
+        package1 = SlackPackage(
+            name="foo-bar",
+            version="1.2.3",
+            build="4",
+            arch=Architecture.X86_64,
+            target="15.0",
+            full_name="foo-bar-1.2.3-x86_64-4_slack15.0",
+            full_version="1.2.3-x86_64-4_slack15.0",
+        )
+        package2 = SlackPackage(
+            name="foo-bar",
+            version="1.2.3",
+            build="4",
+            arch=Architecture.X86_64,
+            target="15.0",
+            full_name="foo-bar-1.2.3-x86_64-4_slack15.0",
+            full_version="1.2.3-x86_64-4_slack15.0",
+        )
+
+        self.assertEqual(package1, package2)
+
+    def test_from_full_name(self):
+        """it should be possible to create packages via the full name"""
+        self.assertIsNone(SlackPackage.from_full_name(None))
+
+        package = SlackPackage.from_full_name("flac-1.3.4-foo-1_slack15.0")
+        self.assertEqual(package.arch, Architecture.UNKNOWN)
+
+        package = SlackPackage.from_full_name("flac-1.3.4-x86_64-1_slack15.0")
+        self.assertEqual(package.arch, Architecture.X86_64)
+        self.assertEqual(package.name, "flac")
+        self.assertEqual(package.version, "1.3.4")
+        self.assertEqual(package.build, "1")
+        self.assertEqual(package.target, "15.0")
+        self.assertEqual(package.full_version, "1.3.4-x86_64-1_slack15.0")
+        self.assertEqual(package.full_name, "flac-1.3.4-x86_64-1_slack15.0")
+
+        package = SlackPackage.from_full_name("kernel-source-5.15.27-noarch-1")
+        self.assertEqual(package.arch, Architecture.NOARCH)
+        self.assertEqual(package.name, "kernel-source")
+        self.assertEqual(package.version, "5.15.27")
+        self.assertEqual(package.build, "1")
+        self.assertEqual(package.target, "")
+        self.assertEqual(package.full_version, "5.15.27-noarch-1")
+        self.assertEqual(package.full_name, "kernel-source-5.15.27-noarch-1")
+
+        package = SlackPackage.from_full_name("libjpeg-v8a-x86_64-2")
+        self.assertEqual(package.arch, Architecture.X86_64)
+        self.assertEqual(package.name, "libjpeg")
+        self.assertEqual(package.version, "v8a")
+        self.assertEqual(package.build, "2")
+        self.assertEqual(package.target, "")
+        self.assertEqual(package.full_version, "v8a-x86_64-2")
+        self.assertEqual(package.full_name, "libjpeg-v8a-x86_64-2")
+
+        package = SlackPackage.from_full_name(" libjpeg-v8a-x86_64-2\r\n")
+        self.assertEqual(package.arch, Architecture.X86_64)
+        self.assertEqual(package.name, "libjpeg")
+        self.assertEqual(package.version, "v8a")
+        self.assertEqual(package.build, "2")
+        self.assertEqual(package.target, "")
+        self.assertEqual(package.full_version, "v8a-x86_64-2")
+        self.assertEqual(package.full_name, "libjpeg-v8a-x86_64-2")
+
+        package = SlackPackage.from_full_name("libjpeg-v8a-x86_64")
+        self.assertIsNone(package)
+
+        package = SlackPackage.from_full_name("libjpeg-v8a-foo-2")
+        self.assertEqual(package.arch, Architecture.UNKNOWN)
+
+    def test_from_name_and_full_version(self):
+        """it should be possible to create packages from name and full
+        version"""
+        self.assertIsNone(SlackPackage.from_name_and_full_version(None, None))
+
+        package = SlackPackage.from_name_and_full_version(
+            "flac", "1.3.4-x86_64-1_slack15.0"
+        )
+        self.assertEqual(package.arch, Architecture.X86_64)
+        self.assertEqual(package.name, "flac")
+        self.assertEqual(package.version, "1.3.4")
+        self.assertEqual(package.build, "1")
+        self.assertEqual(package.target, "15.0")
+        self.assertEqual(package.full_version, "1.3.4-x86_64-1_slack15.0")
+        self.assertEqual(package.full_name, "flac-1.3.4-x86_64-1_slack15.0")
+
+        package = SlackPackage.from_name_and_full_version(
+            "flac", "1.3.4-x86_64"
+        )
+        self.assertIsNone(package)
+
+        package = SlackPackage.from_name_and_full_version("flac", "1.3.4-foo-1")
+        self.assertEqual(package.arch, Architecture.UNKNOWN)


### PR DESCRIPTION
**What**:
Add support for slackware packages
SC-637

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:
Start a scan on a slackware machine. Example for `gvm-cli`:
`gvm-cli --log DEBUG --timeout 3600 --protocol OSP socket --socketpath /home/osp/gb/var/run/ospd/ospd-openvas.sock scan.xml --pretty`
```xml
<start_scan scan_id='97079ee9-8917-49da-aa4f-4ef95f757ac1'>
    <scanner_params>
        <table_driven_lsc>1</table_driven_lsc>
    </scanner_params>
    <vt_selection>
        <vt_single id='1.3.6.1.4.1.25623.1.0.50282'>
        </vt_single>
    </vt_selection>
    <targets>
        <target>
            <hosts>127.0.0.1</hosts>
            <ports>80,8080,443,22,2222</ports>
            <credentials>
                <credential service="ssh" type="up" port="2222">
                    <username>demo</username>
                    <password>demo</password>
                </credential>
            </credentials>
        </target>
    </targets>
    <scanner_params>
    </scanner_params>
</start_scan>
```

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/notus-scanner/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
