### PR TITLE
Allow backporting PRs automatically via mergify (port #258)

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,18 @@
+pull_request_rules:
+  - name: backport main patches to stable branch
+    conditions:
+      - base=main
+      - label=backport-to-stable
+    actions:
+      backport:
+        branches:
+          - stable
+
+  - name: backport stable patches to main branch
+    conditions:
+      - base=stable
+      - label=backport-to-main
+    actions:
+      backport:
+        branches:
+          - main


### PR DESCRIPTION
**What**:

Add mergify config to allow backporting changes from stable to main and
main to stable.

Backport of #258

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/notus-scanner/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
