### PR TITLE
Add: specifier to the report of the result

### DIFF
--- a/notus/scanner/models/packages/package.py
+++ b/notus/scanner/models/packages/package.py
@@ -138,6 +138,7 @@ class PackageAdvisory:
 
     package: Package
     advisory: AdvisoryReference
+    symbol: str
     is_vulnerable: Callable[[Package], bool] = field(compare=False, hash=False)
 
 
@@ -184,7 +185,11 @@ class PackageAdvisories:
         use_verifier = self.is_vulnerable_from_symbol(verifier)
         is_vulnerable = lambda other: use_verifier.verify(package, other)
 
-        advisories.add(PackageAdvisory(package, advisory, is_vulnerable))
+        advisories.add(
+            PackageAdvisory(
+                package, advisory, verifier if verifier else ">=", is_vulnerable
+            )
+        )
         self.advisories[package.name] = advisories
 
     def __len__(self) -> int:

--- a/notus/scanner/models/vulnerability.py
+++ b/notus/scanner/models/vulnerability.py
@@ -16,35 +16,34 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 from dataclasses import dataclass
-from typing import Dict, List
+from typing import Dict
 
+from ..models.advisory import Advisory
 from .packages.package import Package, PackageAdvisory
 
 
 @dataclass
-class Vulnerability:
+class PackageVulnerability:
     """Represents a vulnerable package on a host"""
-
-    package: Package
-    advisory: PackageAdvisory
-
-
-class PackageVulnerabilities:
-    """Represents Vulnerabilities of the same OID"""
 
     host_ip: str
     host_name: str
-    vulnerabilities: Dict[str, List[Vulnerability]]
-    num_vul: int
+    packages: Dict[Package, PackageAdvisory]
+    advisory: Advisory
 
-    def __init__(self, host_ip: str, host_name: str) -> None:
+    def __init__(
+        self,
+        host_ip: str,
+        host_name: str,
+        package: Package,
+        fixed: PackageAdvisory,
+        advisory: Advisory,
+    ) -> None:
         self.host_ip = host_ip
         self.host_name = host_name
-        self.vulnerabilities = {}
-        self.num_vul = 0
+        self.packages = {}
+        self.packages[package] = fixed
+        self.advisory = advisory
 
-    def add_vulnerability(self, oid: str, pack_vul: Vulnerability):
-        if not oid in self.vulnerabilities:
-            self.vulnerabilities[oid] = []
-        self.vulnerabilities[oid].append(pack_vul)
-        self.num_vul = self.num_vul + 1
+    def add_package(self, package: Package, fixed: PackageAdvisory):
+        self.packages[package] = fixed

--- a/notus/scanner/models/vulnerability.py
+++ b/notus/scanner/models/vulnerability.py
@@ -16,34 +16,35 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 from dataclasses import dataclass
-from typing import Dict
+from typing import Dict, List
 
-from ..models.advisory import Advisory
-from .packages.package import Package
+from .packages.package import Package, PackageAdvisory
 
 
 @dataclass
-class PackageVulnerability:
+class Vulnerability:
     """Represents a vulnerable package on a host"""
+
+    package: Package
+    advisory: PackageAdvisory
+
+
+class PackageVulnerabilities:
+    """Represents Vulnerabilities of the same OID"""
 
     host_ip: str
     host_name: str
-    packages: Dict[Package, Package]
-    advisory: Advisory
+    vulnerabilities: Dict[str, List[Vulnerability]]
+    num_vul: int
 
-    def __init__(
-        self,
-        host_ip: str,
-        host_name: str,
-        package: Package,
-        fixed_package: Package,
-        advisory: Advisory,
-    ) -> None:
+    def __init__(self, host_ip: str, host_name: str) -> None:
         self.host_ip = host_ip
         self.host_name = host_name
-        self.packages = {}
-        self.packages[package] = fixed_package
-        self.advisory = advisory
+        self.vulnerabilities = {}
+        self.num_vul = 0
 
-    def add_package(self, package: Package, fixed_package: Package):
-        self.packages[package] = fixed_package
+    def add_vulnerability(self, oid: str, pack_vul: Vulnerability):
+        if not oid in self.vulnerabilities:
+            self.vulnerabilities[oid] = []
+        self.vulnerabilities[oid].append(pack_vul)
+        self.num_vul = self.num_vul + 1

--- a/notus/scanner/scanner.py
+++ b/notus/scanner/scanner.py
@@ -16,7 +16,8 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-from typing import Dict, Iterable, List
+from typing import Iterable
+from notus.scanner.models.packages import package_class_by_type
 
 from .errors import AdvisoriesLoadingError
 from .loader import AdvisoriesLoader
@@ -27,7 +28,7 @@ from .messages.status import ScanStatus, ScanStatusMessage
 from .messaging.publisher import Publisher
 from .models.packages import package_class_by_type
 from .models.packages.package import Package, PackageAdvisories
-from .models.vulnerability import PackageVulnerability
+from .models.vulnerability import PackageVulnerabilities, Vulnerability
 
 logger = logging.getLogger(__name__)
 
@@ -70,27 +71,28 @@ class NotusScanner:
         )
         self._publish(scan_status_message)
 
-    def _publish_result(
-        self, scan_id: str, vulnerability: PackageVulnerability
+    def _publish_results(
+        self, scan_id: str, vulnerabilities: PackageVulnerabilities
     ) -> None:
         report = ""
-        for package, fixed_package in vulnerability.packages.items():
-            report = (
-                report
-                + f"""
-Vulnerable package: {package.name}
-Installed version:  {package.full_name}
-Fixed version:      {fixed_package.full_name}
-"""
+        for oid, vuls in vulnerabilities.vulnerabilities.items():
+            for vul in vuls:
+                report = (
+                    report
+                    + f"""
+    Vulnerable package: {vul.package.name}
+    Installed version:  {vul.package.full_name}
+    Fixed version:      {vul.advisory.symbol}{vul.advisory.package.full_name}
+    """
+                )
+            message = ResultMessage(
+                scan_id=scan_id,
+                host_ip=vulnerabilities.host_ip,
+                host_name=vulnerabilities.host_name,
+                oid=oid,
+                value=report,
             )
-        message = ResultMessage(
-            scan_id=scan_id,
-            host_ip=vulnerability.host_ip,
-            host_name=vulnerability.host_name,
-            oid=vulnerability.advisory.oid,
-            value=report,
-        )
-        self._publish(message)
+            self._publish(message)
 
     def _start_scan(
         self,
@@ -98,36 +100,19 @@ Fixed version:      {fixed_package.full_name}
         host_name: str,
         installed_packages: Iterable[Package],
         package_advisories: PackageAdvisories,
-    ) -> List[PackageVulnerability]:
-        vulnerabilities: Dict[str, PackageVulnerability] = {}
-
-        logger.info(
-            "Start to identify vulnerable packages for %s (%s)",
-            host_ip,
-            host_name,
-        )
-
+    ) -> PackageVulnerabilities:
+        vulnerabilities = PackageVulnerabilities(host_ip, host_name)
         for package in installed_packages:
             package_advisory_list = (
                 package_advisories.get_package_advisories_for_package(package)
             )
             for package_advisory in package_advisory_list:
                 if package_advisory.is_vulnerable(package):
-                    oid = package_advisory.advisory.oid
-                    if oid in vulnerabilities:
-                        vulnerabilities[oid].add_package(
-                            package, package_advisory.package
-                        )
-                    else:
-                        vulnerabilities[oid] = PackageVulnerability(
-                            host_ip=host_ip,
-                            host_name=host_name,
-                            package=package,
-                            fixed_package=package_advisory.package,
-                            advisory=package_advisory.advisory,
-                        )
-
-        return vulnerabilities.values()
+                    vulnerabilities.add_vulnerability(
+                        package_advisory.advisory.oid,
+                        Vulnerability(package, package_advisory),
+                    )
+        return vulnerabilities
 
     def run_scan(
         self,
@@ -205,18 +190,19 @@ Fixed version:      {fixed_package.full_name}
 
         self._start_host(message.scan_id, message.host_ip)
 
-        i = 0
         try:
-            for vulnerability in self._start_scan(
+            vulnerabilities = self._start_scan(
                 host_ip=message.host_ip,
                 host_name=message.host_name,
                 installed_packages=installed_packages,
                 package_advisories=package_advisories,
-            ):
-                i += 1
-                self._publish_result(message.scan_id, vulnerability)
+            )
+            self._publish_results(message.scan_id, vulnerabilities)
 
-            logger.info("Total number of vulnerable packages -> %d", i)
+            logger.info(
+                "Total number of vulnerable packages -> %d",
+                vulnerabilities.num_vul,
+            )
 
             self._finish_host(message.scan_id, message.host_ip)
 

--- a/smoketest/products/init.go
+++ b/smoketest/products/init.go
@@ -50,6 +50,12 @@ func (a *Advisory) FindByFullName(fullname string) *FixedPackage {
 }
 
 func (a *Advisory) Find(value string) *FixedPackage {
+	if strings.HasPrefix(value, ">") || strings.HasPrefix(value, "<") || strings.HasPrefix(value, "=") {
+		value = value[1:]
+		if strings.HasPrefix(value, "=") {
+			value = value[1:]
+		}
+	}
 	if found := a.FindByFullName(value); found != nil {
 		return found
 	}

--- a/tests/models/packages/test_package.py
+++ b/tests/models/packages/test_package.py
@@ -112,7 +112,10 @@ class PackageAdvisoryTestCase(TestCase):
         )
 
         package_advisory = PackageAdvisory(
-            package=package, advisory=advisory, is_vulnerable=lambda _: False
+            package=package,
+            advisory=advisory,
+            symbol=">=",
+            is_vulnerable=lambda _: False,
         )
 
         self.assertEqual(package_advisory.package, package)
@@ -133,7 +136,10 @@ class PackageAdvisoryTestCase(TestCase):
         )
 
         package_advisory = PackageAdvisory(
-            package=package1, advisory=advisory1, is_vulnerable=lambda _: False
+            package=package1,
+            advisory=advisory1,
+            symbol=">=",
+            is_vulnerable=lambda _: False,
         )
 
         with self.assertRaises(FrozenInstanceError):
@@ -160,16 +166,28 @@ class PackageAdvisoryTestCase(TestCase):
         )
 
         package_advisory1 = PackageAdvisory(
-            package=package1, advisory=advisory1, is_vulnerable=lambda _: False
+            package=package1,
+            advisory=advisory1,
+            symbol=">=",
+            is_vulnerable=lambda _: False,
         )
         package_advisory2 = PackageAdvisory(
-            package=package2, advisory=advisory2, is_vulnerable=lambda _: False
+            package=package2,
+            advisory=advisory2,
+            symbol=">=",
+            is_vulnerable=lambda _: False,
         )
         package_advisory3 = PackageAdvisory(
-            package=package1, advisory=advisory1, is_vulnerable=lambda _: False
+            package=package1,
+            advisory=advisory1,
+            symbol=">=",
+            is_vulnerable=lambda _: False,
         )
         package_advisory4 = PackageAdvisory(
-            package=package1, advisory=advisory2, is_vulnerable=lambda _: False
+            package=package1,
+            advisory=advisory2,
+            symbol=">=",
+            is_vulnerable=lambda _: False,
         )
 
         self.assertEqual(package_advisory1, package_advisory1)
@@ -194,16 +212,28 @@ class PackageAdvisoryTestCase(TestCase):
         )
 
         package_advisory1 = PackageAdvisory(
-            package=package1, advisory=advisory1, is_vulnerable=lambda _: False
+            package=package1,
+            advisory=advisory1,
+            symbol=">=",
+            is_vulnerable=lambda _: False,
         )
         package_advisory2 = PackageAdvisory(
-            package=package2, advisory=advisory2, is_vulnerable=lambda _: False
+            package=package2,
+            advisory=advisory2,
+            symbol=">=",
+            is_vulnerable=lambda _: False,
         )
         package_advisory3 = PackageAdvisory(
-            package=package1, advisory=advisory1, is_vulnerable=lambda _: False
+            package=package1,
+            advisory=advisory1,
+            symbol=">=",
+            is_vulnerable=lambda _: False,
         )
         package_advisory4 = PackageAdvisory(
-            package=package1, advisory=advisory2, is_vulnerable=lambda _: False
+            package=package1,
+            advisory=advisory2,
+            symbol=">=",
+            is_vulnerable=lambda _: False,
         )
 
         self.assertEqual(hash(package_advisory1), hash(package_advisory1))

--- a/tests/models/test_vulnerability.py
+++ b/tests/models/test_vulnerability.py
@@ -15,24 +15,39 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+from datetime import datetime
 from unittest import TestCase
 
+from notus.scanner.models.advisory import Advisory, Severity
 from notus.scanner.models.packages.package import (
     PackageAdvisory,
     AdvisoryReference,
 )
 from notus.scanner.models.packages.rpm import RPMPackage
-from notus.scanner.models.vulnerability import (
-    PackageVulnerabilities,
-    Vulnerability,
-)
+from notus.scanner.models.vulnerability import PackageVulnerability
 
 
 class PackageVulnerabilityTestCase(TestCase):
     def test_constructor(self):
         host_ip = "123.456.789.10"
         host_name = "foo"
-        oid = "1.2.3.4.5"
+
+        severity_date = datetime(year=2021, month=1, day=2, hour=11, minute=11)
+        creation_date = datetime(year=2021, month=3, day=21, hour=10, minute=0)
+        last_modification = datetime.now()
+        severity = Severity(
+            origin="foo",
+            date=severity_date,
+        )
+        advisory = Advisory(
+            oid="1.2.3.4.5",
+            title="Foo Bar",
+            creation_date=creation_date,
+            last_modification=last_modification,
+            advisory_id="1234",
+            advisory_xref="http://foo/1234",
+            severity=severity,
+        )
 
         package = RPMPackage.from_full_name(
             "foo-bar-1.2.3-4.x86_64",
@@ -42,38 +57,35 @@ class PackageVulnerabilityTestCase(TestCase):
             "foo-bar-1.2.4-4.x86_64",
         )
 
-        pack_advisory = PackageAdvisory(
-            fixed_package, AdvisoryReference(oid), ">=", lambda _: True
+        fixed = PackageAdvisory(
+            fixed_package, AdvisoryReference("1.2.3.4.5"), ">=", lambda _: False
         )
 
-        package_vulnerability = PackageVulnerabilities(
-            host_ip=host_ip, host_name=host_name
-        )
-        package_vulnerability.add_vulnerability(
-            oid,
-            Vulnerability(package, pack_advisory),
+        package_vulnerability = PackageVulnerability(
+            host_ip=host_ip,
+            host_name=host_name,
+            advisory=advisory,
+            package=package,
+            fixed=fixed,
         )
 
         self.assertEqual(package_vulnerability.host_ip, host_ip)
         self.assertEqual(package_vulnerability.host_name, host_name)
 
-        v_oid, vul = next(iter(package_vulnerability.vulnerabilities.items()))
-        self.assertEqual(v_oid, oid)
+        advisory = package_vulnerability.advisory
+        self.assertEqual(advisory.oid, "1.2.3.4.5")
 
-        package, advisory = vul[0].package, vul[0].advisory
+        package, fixed = next(iter(package_vulnerability.packages.items()))
         self.assertEqual(package.name, "foo-bar")
         self.assertEqual(package.version, "1.2.3")  # pylint: disable=no-member
         self.assertEqual(package.release, "4")  # pylint: disable=no-member
         self.assertEqual(package.full_name, "foo-bar-1.2.3-4.x86_64")
 
-        self.assertEqual(advisory.package.name, "foo-bar")
+        self.assertEqual(fixed.package.name, "foo-bar")
         self.assertEqual(
-            advisory.package.version, "1.2.4"  # pylint: disable=no-member
+            fixed.package.version, "1.2.4"  # pylint: disable=no-member
         )
         self.assertEqual(
-            advisory.package.release, "4"  # pylint: disable=no-member
+            fixed.package.release, "4"  # pylint: disable=no-member
         )
-        self.assertEqual(advisory.package.full_name, "foo-bar-1.2.4-4.x86_64")
-        self.assertEqual(advisory.is_vulnerable(package), True)
-        self.assertEqual(advisory.symbol, ">=")
-        self.assertEqual(advisory.advisory.oid, oid)
+        self.assertEqual(fixed.package.full_name, "foo-bar-1.2.4-4.x86_64")

--- a/tests/models/test_vulnerability.py
+++ b/tests/models/test_vulnerability.py
@@ -15,35 +15,24 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-from datetime import datetime
 from unittest import TestCase
 
-from notus.scanner.models.advisory import Advisory, Severity
+from notus.scanner.models.packages.package import (
+    PackageAdvisory,
+    AdvisoryReference,
+)
 from notus.scanner.models.packages.rpm import RPMPackage
-from notus.scanner.models.vulnerability import PackageVulnerability
+from notus.scanner.models.vulnerability import (
+    PackageVulnerabilities,
+    Vulnerability,
+)
 
 
 class PackageVulnerabilityTestCase(TestCase):
     def test_constructor(self):
         host_ip = "123.456.789.10"
         host_name = "foo"
-
-        severity_date = datetime(year=2021, month=1, day=2, hour=11, minute=11)
-        creation_date = datetime(year=2021, month=3, day=21, hour=10, minute=0)
-        last_modification = datetime.now()
-        severity = Severity(
-            origin="foo",
-            date=severity_date,
-        )
-        advisory = Advisory(
-            oid="1.2.3.4.5",
-            title="Foo Bar",
-            creation_date=creation_date,
-            last_modification=last_modification,
-            advisory_id="1234",
-            advisory_xref="http://foo/1234",
-            severity=severity,
-        )
+        oid = "1.2.3.4.5"
 
         package = RPMPackage.from_full_name(
             "foo-bar-1.2.3-4.x86_64",
@@ -53,33 +42,38 @@ class PackageVulnerabilityTestCase(TestCase):
             "foo-bar-1.2.4-4.x86_64",
         )
 
-        package_vulnerability = PackageVulnerability(
-            host_ip=host_ip,
-            host_name=host_name,
-            advisory=advisory,
-            package=package,
-            fixed_package=fixed_package,
+        pack_advisory = PackageAdvisory(
+            fixed_package, AdvisoryReference(oid), ">=", lambda _: True
+        )
+
+        package_vulnerability = PackageVulnerabilities(
+            host_ip=host_ip, host_name=host_name
+        )
+        package_vulnerability.add_vulnerability(
+            oid,
+            Vulnerability(package, pack_advisory),
         )
 
         self.assertEqual(package_vulnerability.host_ip, host_ip)
         self.assertEqual(package_vulnerability.host_name, host_name)
 
-        advisory = package_vulnerability.advisory
-        self.assertEqual(advisory.oid, "1.2.3.4.5")
+        v_oid, vul = next(iter(package_vulnerability.vulnerabilities.items()))
+        self.assertEqual(v_oid, oid)
 
-        package, fixed_package = next(
-            iter(package_vulnerability.packages.items())
-        )
+        package, advisory = vul[0].package, vul[0].advisory
         self.assertEqual(package.name, "foo-bar")
         self.assertEqual(package.version, "1.2.3")  # pylint: disable=no-member
         self.assertEqual(package.release, "4")  # pylint: disable=no-member
         self.assertEqual(package.full_name, "foo-bar-1.2.3-4.x86_64")
 
-        self.assertEqual(fixed_package.name, "foo-bar")
+        self.assertEqual(advisory.package.name, "foo-bar")
         self.assertEqual(
-            fixed_package.version, "1.2.4"  # pylint: disable=no-member
+            advisory.package.version, "1.2.4"  # pylint: disable=no-member
         )
         self.assertEqual(
-            fixed_package.release, "4"  # pylint: disable=no-member
+            advisory.package.release, "4"  # pylint: disable=no-member
         )
-        self.assertEqual(fixed_package.full_name, "foo-bar-1.2.4-4.x86_64")
+        self.assertEqual(advisory.package.full_name, "foo-bar-1.2.4-4.x86_64")
+        self.assertEqual(advisory.is_vulnerable(package), True)
+        self.assertEqual(advisory.symbol, ">=")
+        self.assertEqual(advisory.advisory.oid, oid)

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -16,16 +16,17 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import json
+from typing import List, Optional, Tuple
 import unittest
 from pathlib import Path
-from typing import List, Optional, Tuple
 
-from notus.scanner.loader.gpg_sha_verifier import VerificationResult
-from notus.scanner.loader.json import JSONAdvisoriesLoader
-from notus.scanner.messages.message import Message
+
 from notus.scanner.messages.start import ScanStartMessage
+from notus.scanner.messages.message import Message
 from notus.scanner.messaging.publisher import Publisher
 from notus.scanner.scanner import NotusScanner
+from notus.scanner.loader.gpg_sha_verifier import VerificationResult
+from notus.scanner.loader.json import JSONAdvisoriesLoader
 
 _here = Path(__file__).parent
 
@@ -39,7 +40,7 @@ class FakePublisher(Publisher):
         values = str(serialized.get("value", "")).split("\n")
         for value in values:
             if value.find("Installed version:") >= 0:
-                installed = value[len("Installed version: ") :].strip()
+                installed = value.split(":")[1].strip()
                 self.results.append(installed)
 
 
@@ -84,10 +85,8 @@ class VerifierTestCase(unittest.TestCase):
         not_in = []
         # cases that should appear in result
         is_in = []
-        for verylongvariablenamecaseforpylint in cases:
-            c_not_in, c_is_in = self.per_symbol(
-                *verylongvariablenamecaseforpylint
-            )
+        for case in cases:
+            c_not_in, c_is_in = self.per_symbol(*case)
             not_in = not_in + c_not_in
             is_in = is_in + c_is_in
         # packagelist is both combined


### PR DESCRIPTION
**What**:
The specifier is a tool to specify the comparison between packages. This leads to confusing results, as the specifier will not appear in the result, so results with the same installed and fixed version will be possible. To fix this, the specifier will be part of the report of the result and is contained in the fixed version. Example: `{ "name": null, "full_version": null, "full_name": "slackpkg-15.0.10-noarch-1", "specifier": ">"}` can lead to the result
Vulnerable package: slackpkg
Installed version:  slackpkg-15.0.10-noarch-1
Fixed version:      slackpkg-15.0.10-noarch-1

This will be fixed to:
Vulnerable package: slackpkg
Installed version:  slackpkg-15.0.10-noarch-1
Fixed version:      >slackpkg-15.0.10-noarch-1

SC-674

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/notus-scanner/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
