### PR TITLE
Fix: False positive Debian Package Comparison

### DIFF
--- a/notus/scanner/models/packages/deb.py
+++ b/notus/scanner/models/packages/deb.py
@@ -49,12 +49,29 @@ class DEBPackage(Package):
 
     __hash__ = Package.__hash__
 
-    def _compare(self, other: Package) -> PackageComparison:
-        a_version = parse(self.full_version)
-        b_version = parse(other.full_version)
-
-        if a_version == b_version:
+    def _compare(self, other: "DEBPackage") -> PackageComparison:
+        if self.full_version == other.full_version:
             return PackageComparison.EQUAL
+
+        if self.epoch != other.epoch:
+            return (
+                PackageComparison.A_NEWER
+                if self.epoch > other.epoch
+                else PackageComparison.B_NEWER
+            )
+
+        a_version = parse(self.upstream_version)
+        b_version = parse(other.upstream_version)
+
+        if a_version != b_version:
+            return (
+                PackageComparison.A_NEWER
+                if a_version > b_version
+                else PackageComparison.B_NEWER
+            )
+
+        a_version = parse(self.debian_revision)
+        b_version = parse(other.debian_revision)
 
         return (
             PackageComparison.A_NEWER

--- a/tests/models/packages/test_deb.py
+++ b/tests/models/packages/test_deb.py
@@ -102,6 +102,16 @@ class DEBPackageTestCase(TestCase):
         )
         self.assertLess(package1, package2)
 
+        package2 = DEBPackage(
+            name="foo-bar",
+            epoch="1",
+            upstream_version="1.2.3~rc",
+            debian_revision="4",
+            full_name="foo-bar-1:1.2.3~rc-4",
+            full_version="1:1.2.3~rc-4",
+        )
+        self.assertLess(package2, package1)
+
     def test_compare_equal(self):
         """packages with the same data should be equal"""
         package1 = DEBPackage(


### PR DESCRIPTION
**What**:
In some cases the comparison for Debian packages was not correct, as the single parts of the version were not compared part by part, but as a whole. This lead to false positive results as e.g.:
`2.7.15-4ubuntu4~18.04` was reported to be older then `2.7.15~rc1-1ubuntu0.1`, even though in this case it is the other way around. This PR will fix this issue.
SC-677

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/notus-scanner/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
