### PR TITLE
Fix: parsing for debian packages with a - in the name

### DIFF
--- a/notus/scanner/models/packages/deb.py
+++ b/notus/scanner/models/packages/deb.py
@@ -27,8 +27,8 @@ from packaging.version import parse
 
 from .package import Package, PackageComparison
 
-_deb_compile = re.compile(r"(.*)-(?:(\d*):)?(.*)-(.*)")
-_deb_compile_wo_revision = re.compile(r"(.*)-(?:(\d*):)?(.*)")
+_deb_compile = re.compile(r"(.*)-(?:(\d*):)?(\d.*)-(.*)")
+_deb_compile_wo_revision = re.compile(r"(.*)-(?:(\d*):)?(\d.*)")
 _deb_compile_version = re.compile(r"(?:(\d*):)?(\d.*)-(.*)")
 _deb_compile_version_wo_revision = re.compile(r"(?:(\d*):)?(\d.*)")
 

--- a/tests/models/packages/test_deb.py
+++ b/tests/models/packages/test_deb.py
@@ -186,6 +186,13 @@ class DEBPackageTestCase(TestCase):
         self.assertEqual(package.debian_revision, "")
         self.assertEqual(package.full_name, "ucf-3.0038+nmu1")
 
+        package = DEBPackage.from_full_name("apport-symptoms-020")
+        self.assertEqual(package.name, "apport-symptoms")
+        self.assertEqual(package.epoch, "0")
+        self.assertEqual(package.upstream_version, "020")
+        self.assertEqual(package.debian_revision, "")
+        self.assertEqual(package.full_name, "apport-symptoms-020")
+
     def test_from_name_and_full_version(self):
         """it should be possible to create packages from name and full
         version"""


### PR DESCRIPTION
**What**:
In case the name of a package contained a `-`, like apport-symptoms-0.20 it was parsed to Name: apport
Full Version: symptoms-0.20
even though symptoms is part of the name.

This was the case beacause of a small mistake within the regular expression, which did not check if the version starts with a number, which is necessary for Debian packages.

Now the package will be parsed to
Name: apport-symptoms
Full version:0.20

SC-682

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/notus-scanner/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
