### PR TITLE
Refactor: use own version comparison instead of packaging.version

### DIFF
--- a/notus/scanner/models/packages/ebuild.py
+++ b/notus/scanner/models/packages/ebuild.py
@@ -34,8 +34,6 @@ of pep440 to guess immediately.
 import logging
 from dataclasses import dataclass
 
-from packaging.version import Version
-
 from .package import Package, PackageComparison
 
 logger = logging.getLogger(__name__)
@@ -46,21 +44,13 @@ class EBuildPackage(Package):
     """Represents a .ebuild based package"""
 
     def _compare(self, other: Package) -> PackageComparison:
-        # we don't want to deal with LegacyVersion
-        a_version = Version(self.full_version)
-        b_version = Version(other.full_version)
-
         if self.name != other.name:
             return PackageComparison.NOT_COMPARABLE
 
-        if a_version == b_version:
+        if self.full_version == other.full_version:
             return PackageComparison.EQUAL
 
-        return (
-            PackageComparison.A_NEWER
-            if a_version > b_version
-            else PackageComparison.B_NEWER
-        )
+        return self.version_compare(self.full_version, other.full_version)
 
     @staticmethod
     def from_full_name(full_name: str):

--- a/notus/scanner/models/packages/slackware.py
+++ b/notus/scanner/models/packages/slackware.py
@@ -45,21 +45,18 @@ class SlackPackage(Package):
     __hash__ = Package.__hash__
 
     def _compare(self, other: "SlackPackage") -> PackageComparison:
+        if self.name != other.name:
+            return PackageComparison.NOT_COMPARABLE
+
         if self.arch != other.arch:
             return PackageComparison.NOT_COMPARABLE
 
         if self.full_version == other.full_version:
             return PackageComparison.EQUAL
 
-        a_version = parse(self.version)
-        b_version = parse(other.version)
-
-        if a_version != b_version:
-            return (
-                PackageComparison.A_NEWER
-                if a_version > b_version
-                else PackageComparison.B_NEWER
-            )
+        comp = self.version_compare(self.version, other.version)
+        if comp != PackageComparison.EQUAL:
+            return comp
 
         a_target = parse(self.target)
         b_target = parse(other.target)
@@ -70,16 +67,11 @@ class SlackPackage(Package):
                 if a_target > b_target
                 else PackageComparison.B_NEWER
             )
+        comp = self.version_compare(self.target, other.target)
+        if comp != PackageComparison.EQUAL:
+            return comp
 
-        a_build = parse(self.build)
-        b_build = parse(other.build)
-
-        if a_build != b_build:
-            return (
-                PackageComparison.A_NEWER
-                if a_build > b_build
-                else PackageComparison.B_NEWER
-            )
+        return self.version_compare(self.build, other.build)
 
     @staticmethod
     def from_full_name(full_name: str):

--- a/tests/models/packages/test_deb.py
+++ b/tests/models/packages/test_deb.py
@@ -51,22 +51,22 @@ class DEBPackageTestCase(TestCase):
         )
         self.assertGreater(package2, package1)
 
-    def test_compare_gt_different_architecture(self):
-        """packages of different architecture should not be comparable"""
+    def test_compare_gt_different_name(self):
+        """different packagtes should not be comparable"""
         package1 = DEBPackage(
-            name="foo-bar",
+            name="foo",
             epoch="1",
             upstream_version="1.2.3",
             debian_revision="4",
-            full_name="foo-bar-1:1.2.3-4",
+            full_name="foo-1:1.2.3-4",
             full_version="1:1.2.3-4",
         )
         package2 = DEBPackage(
-            name="foo-bar",
+            name="bar",
             epoch="1",
             upstream_version="1.2.3",
             debian_revision="4",
-            full_name="foo-bar-1:1.2.3-4",
+            full_name="bar-1:1.2.3-4",
             full_version="1:1.2.3-4",
         )
         self.assertFalse(package2 > package1)

--- a/tests/models/packages/test_package.py
+++ b/tests/models/packages/test_package.py
@@ -26,6 +26,7 @@ from notus.scanner.models.packages.package import (
     Package,
     PackageAdvisories,
     PackageAdvisory,
+    PackageComparison,
     PackageType,
 )
 from notus.scanner.models.packages.rpm import RPMPackage
@@ -82,6 +83,57 @@ class PackageTestCase(TestCase):
         with self.assertRaises(PackageError):
             if package1 > package2:
                 self.fail("PackageError should occur")
+
+    def test_version_compare(self):
+        version_a = "1.2.3"
+        version_b = "1.2.3"
+        ret = Package.version_compare(version_a, version_b)
+        self.assertEqual(ret, PackageComparison.EQUAL)
+
+        version_a = "1.2.3"
+        version_b = "1.2.12"
+        ret = Package.version_compare(version_a, version_b)
+        self.assertEqual(ret, PackageComparison.B_NEWER)
+
+        version_a = "1.2.3"
+        version_b = "1.2.3a"
+        ret = Package.version_compare(version_a, version_b)
+        self.assertEqual(ret, PackageComparison.B_NEWER)
+
+        version_a = "1.2.3~rc0"
+        version_b = "1.2.3"
+        ret = Package.version_compare(version_a, version_b)
+        self.assertEqual(ret, PackageComparison.B_NEWER)
+
+        version_a = "1.2.3a"
+        version_b = "1.2.3b"
+        ret = Package.version_compare(version_a, version_b)
+        self.assertEqual(ret, PackageComparison.B_NEWER)
+
+        version_a = "1.2.3a"
+        version_b = "1.2.3-2"
+        ret = Package.version_compare(version_a, version_b)
+        self.assertEqual(ret, PackageComparison.B_NEWER)
+
+        version_a = "1.2"
+        version_b = "1.2.3"
+        ret = Package.version_compare(version_a, version_b)
+        self.assertEqual(ret, PackageComparison.B_NEWER)
+
+        version_a = "1.1.1c"
+        version_b = "1.1.1k"
+        ret = Package.version_compare(version_a, version_b)
+        self.assertEqual(ret, PackageComparison.B_NEWER)
+
+        version_a = "1.2.3.1"
+        version_b = "1.2.3_a"
+        ret = Package.version_compare(version_a, version_b)
+        self.assertEqual(ret, PackageComparison.B_NEWER)
+
+        version_a = "1.2.3_a"
+        version_b = "1.2.3_1"
+        ret = Package.version_compare(version_a, version_b)
+        self.assertEqual(ret, PackageComparison.B_NEWER)
 
 
 class ArchitectureTestCase(TestCase):

--- a/tests/models/packages/test_rpm.py
+++ b/tests/models/packages/test_rpm.py
@@ -93,6 +93,27 @@ class RPMPackageTestCase(TestCase):
         self.assertFalse(package4 > package1)
         self.assertFalse(package1 > package4)
 
+    def test_compare_gt_different_name(self):
+        """different packagtes should not be comparable"""
+        package1 = RPMPackage(
+            name="foo",
+            version="1.2.3",
+            release="4",
+            arch=Architecture.X86_64,
+            full_name="foo-1.2.3-4.x86_64",
+            full_version="1.2.3-4.x86_64",
+        )
+        package2 = RPMPackage(
+            name="bar",
+            version="1.2.3",
+            release="4",
+            arch=Architecture.X86_64,
+            full_name="bar-1.2.3-4.x86_64",
+            full_version="1.2.3-4.x86_64",
+        )
+        self.assertFalse(package2 > package1)
+        self.assertFalse(package1 > package2)
+
     def test_compare_less(self):
         """packages should be comparable"""
         package1 = RPMPackage(

--- a/tests/models/packages/test_slackware.py
+++ b/tests/models/packages/test_slackware.py
@@ -122,6 +122,29 @@ class SlackPackageTestCase(TestCase):
         self.assertFalse(package5 > package1)
         self.assertFalse(package1 > package5)
 
+    def test_compare_gt_different_name(self):
+        """different packagtes should not be comparable"""
+        package1 = SlackPackage(
+            name="foo",
+            version="1.2.3",
+            build="4",
+            arch=Architecture.X86_64,
+            target="15.0",
+            full_name="foo-1.2.3-x86_64-4_slack15.0",
+            full_version="1.2.3-x86_64-4_slack15.0",
+        )
+        package2 = SlackPackage(
+            name="bar",
+            version="1.2.3",
+            build="4",
+            arch=Architecture.X86_64,
+            target="15.0",
+            full_name="bar-1.2.3-x86_64-4_slack15.0",
+            full_version="1.2.3-x86_64-4_slack15.0",
+        )
+        self.assertFalse(package2 > package1)
+        self.assertFalse(package1 > package2)
+
     def test_compare_less(self):
         """packages should be comparable"""
         package1 = SlackPackage(


### PR DESCRIPTION
**What**:
The Version module of packaging.version is meant to store the Version of python packages. This now lead to a problem, in which part of the Version, which was parsed was transformed, e.g. `1.1.1c` was parsed as `1.1.1rc0` which resulted in a false positive vulnerability detection. This is fixed with this PR.

SC-691

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/notus-scanner/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
