### PR TITLE
Fix: RPM package comparison by adding exceptions for version

### DIFF
--- a/notus/scanner/models/packages/rpm.py
+++ b/notus/scanner/models/packages/rpm.py
@@ -18,6 +18,11 @@ _rpm_compile_version = re.compile(r"([^-]+)-([^-]+)\.([^-]+)")
 
 logger = logging.getLogger(__name__)
 
+excpetions = [
+    "_fips",
+    ".ksplice",
+]
+
 
 @dataclass
 class RPMPackage(Package):
@@ -32,6 +37,12 @@ class RPMPackage(Package):
     def _compare(self, other: "RPMPackage") -> PackageComparison:
         if self.arch != other.arch:
             return PackageComparison.NOT_COMPARABLE
+
+        for e in excpetions:
+            if (self.full_version.find(e) > -1) != (
+                other.full_version.find(e) > -1
+            ):
+                return PackageComparison.NOT_COMPARABLE
 
         if self.full_version == other.full_version:
             return PackageComparison.EQUAL

--- a/tests/models/packages/test_rpm.py
+++ b/tests/models/packages/test_rpm.py
@@ -253,3 +253,33 @@ class RPMPackageTestCase(TestCase):
         self.assertEqual(package.version, "1.6.3")
         self.assertEqual(package.release, "26.h1")
         self.assertEqual(package.full_name, "cups-libs-1.6.3-26.h1.x86_64")
+
+    def test_exceptions(self):
+        """tests for the exceptions _fips and .ksplice"""
+        package1 = RPMPackage.from_full_name("gnutls-3.6.16-4.el8.x86_64")
+        package2 = RPMPackage.from_full_name(
+            "gnutls-3.6.16-4.0.1.el8_fips.x86_64"
+        )
+
+        self.assertFalse(package1 > package2)
+        self.assertFalse(package2 > package1)
+
+        package1 = RPMPackage.from_full_name("gnutls-3.6.16-4.el8_fips.x86_64")
+
+        self.assertTrue(package2 > package1)
+
+        package1 = RPMPackage.from_full_name(
+            "openssl-libs-1.0.2k-24.0.3.el7_8.x86_64"
+        )
+        package2 = RPMPackage.from_full_name(
+            "openssl-libs-1.0.2k-24.0.3.ksplice1.el7_9.x86_64"
+        )
+
+        self.assertFalse(package1 > package2)
+        self.assertFalse(package2 > package1)
+
+        package1 = RPMPackage.from_full_name(
+            "openssl-libs-1.0.2k-24.0.3.ksplice1.el7_8.x86_64"
+        )
+
+        self.assertTrue(package2 > package1)


### PR DESCRIPTION
**What**:
In some cases RPM package versions containing a '.ksplice' or a '_fips' string. These versions are not comparable with other Versions missing this string.

SC-690

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/notus-scanner/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
