### PR TITLE
Fix: _check_package returns None although there are vulnerabilities

### DIFF
--- a/notus/scanner/models/packages/deb.py
+++ b/notus/scanner/models/packages/deb.py
@@ -43,7 +43,7 @@ class DEBPackage(Package):
 
     __hash__ = Package.__hash__
 
-    def _compare(self, other: "DEBPackage") -> PackageComparison:
+    def compare(self, other: "DEBPackage") -> PackageComparison:
         if self.name != other.name:
             return PackageComparison.NOT_COMPARABLE
 

--- a/notus/scanner/models/packages/ebuild.py
+++ b/notus/scanner/models/packages/ebuild.py
@@ -43,7 +43,7 @@ logger = logging.getLogger(__name__)
 class EBuildPackage(Package):
     """Represents a .ebuild based package"""
 
-    def _compare(self, other: Package) -> PackageComparison:
+    def compare(self, other: Package) -> PackageComparison:
         if self.name != other.name:
             return PackageComparison.NOT_COMPARABLE
 

--- a/notus/scanner/models/packages/package.py
+++ b/notus/scanner/models/packages/package.py
@@ -163,7 +163,10 @@ class PackageAdvisory:
     package: Package
     oid: str
     symbol: str
-    is_vulnerable: Callable[[Package], bool] = field(compare=False, hash=False)
+    # returns None when not comparable otherwise true or false
+    is_vulnerable: Callable[[Package], Optional[bool]] = field(
+        compare=False, hash=False
+    )
 
 
 @dataclass(frozen=True)
@@ -176,12 +179,26 @@ class PackageAdvisories:
         default_factory=dict
     )
 
+    is_comparable = (
+        lambda a, b: a._compare(b) != PackageComparison.NOT_COMPARABLE
+    )
+
     comparison_map = {
-        ">=": lambda a, b: a > b,
-        "<=": lambda a, b: a < b,
-        "=": lambda a, b: a != b,
-        "<": lambda a, b: a <= b,
-        ">": lambda a, b: a >= b,
+        ">=": lambda a, b: a > b
+        if PackageAdvisories.is_comparable(a, b)
+        else None,
+        "<=": lambda a, b: a < b
+        if PackageAdvisories.is_comparable(a, b)
+        else None,
+        "=": lambda a, b: a != b
+        if PackageAdvisories.is_comparable(a, b)
+        else None,
+        "<": lambda a, b: a <= b
+        if PackageAdvisories.is_comparable(a, b)
+        else None,
+        ">": lambda a, b: a >= b
+        if PackageAdvisories.is_comparable(a, b)
+        else None,
     }
 
     def get_package_advisories_for_package(

--- a/notus/scanner/models/packages/package.py
+++ b/notus/scanner/models/packages/package.py
@@ -58,15 +58,15 @@ class Package:
 
     def __gt__(self, other: Any) -> bool:
         self.__guard_cmp(other)
-        return self._compare(other) == PackageComparison.A_NEWER
+        return self.compare(other) == PackageComparison.A_NEWER
 
     def __lt__(self, other: Any) -> bool:
         self.__guard_cmp(other)
-        return self._compare(other) == PackageComparison.B_NEWER
+        return self.compare(other) == PackageComparison.B_NEWER
 
     def __eq__(self, other: Any) -> bool:
         self.__guard_cmp(other)
-        return self._compare(other) == PackageComparison.EQUAL
+        return self.compare(other) == PackageComparison.EQUAL
 
     def __ge__(self, other: Any) -> bool:
         return self.__gt__(other) or self.__eq__(other)
@@ -142,7 +142,7 @@ class Package:
         return PackageComparison.EQUAL
 
     @abstractmethod
-    def _compare(self, other: Any) -> PackageComparison:
+    def compare(self, other: Any) -> PackageComparison:
         raise NotImplementedError()
 
     @staticmethod
@@ -180,7 +180,7 @@ class PackageAdvisories:
     )
 
     is_comparable = (
-        lambda a, b: a._compare(b) != PackageComparison.NOT_COMPARABLE
+        lambda a, b: a.compare(b) != PackageComparison.NOT_COMPARABLE
     )
 
     comparison_map = {

--- a/notus/scanner/models/packages/rpm.py
+++ b/notus/scanner/models/packages/rpm.py
@@ -30,7 +30,7 @@ class RPMPackage(Package):
 
     __hash__ = Package.__hash__
 
-    def _compare(self, other: "RPMPackage") -> PackageComparison:
+    def compare(self, other: "RPMPackage") -> PackageComparison:
         if self.name != other.name:
             return PackageComparison.NOT_COMPARABLE
 

--- a/notus/scanner/models/packages/slackware.py
+++ b/notus/scanner/models/packages/slackware.py
@@ -44,7 +44,7 @@ class SlackPackage(Package):
 
     __hash__ = Package.__hash__
 
-    def _compare(self, other: "SlackPackage") -> PackageComparison:
+    def compare(self, other: "SlackPackage") -> PackageComparison:
         if self.name != other.name:
             return PackageComparison.NOT_COMPARABLE
 

--- a/notus/scanner/scanner.py
+++ b/notus/scanner/scanner.py
@@ -16,7 +16,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-from typing import Iterable, List, Optional, Set
+from typing import Iterable, List, Set, Optional
 
 from notus.scanner.models.packages import package_class_by_type
 
@@ -108,12 +108,22 @@ class NotusScanner:
     def _check_package(
         package: Package, package_advisory_list: Set[PackageAdvisory]
     ) -> Optional[Vulnerability]:
+
         vul = Vulnerability()
-
         for package_advisory in package_advisory_list:
-
-            if not package_advisory.is_vulnerable(package):
+            logger.debug(
+                "%s verify package %s %s %s",
+                package_advisory.oid,
+                package,
+                package_advisory.symbol,
+                package_advisory.package,
+            )
+            is_vulnerable = package_advisory.is_vulnerable(package)
+            if is_vulnerable == None:
+                continue
+            elif not is_vulnerable:
                 return
+
             vul.add(package, package_advisory)
 
         return vul
@@ -133,7 +143,7 @@ class NotusScanner:
             for oid, package_advisory_list in package_advisory_oids.items():
 
                 vul = self._check_package(package, package_advisory_list)
-                if vul:
+                if vul and vul.vulnerability:
                     vulnerabilities.add(oid, vul)
 
         return vulnerabilities

--- a/notus/scanner/scanner.py
+++ b/notus/scanner/scanner.py
@@ -119,7 +119,7 @@ class NotusScanner:
                 package_advisory.package,
             )
             is_vulnerable = package_advisory.is_vulnerable(package)
-            if is_vulnerable == None:
+            if is_vulnerable is None:
                 continue
             elif not is_vulnerable:
                 return

--- a/tests/fakespecifier_os.notus
+++ b/tests/fakespecifier_os.notus
@@ -28,7 +28,31 @@
         },
         {
           "full_name": "default-9.2.15-1.x86_64"
+        },
+        {
+          "full_name": "eq-9.2.15-1.aarch64",
+          "specifier": "="
+        },
+        {
+          "full_name": "lt-9.2.15-1.aarch64",
+          "specifier": "<"
+        },
+        {
+          "full_name": "le-9.2.15-1.aarch64",
+          "specifier": "<="
+        },
+        {
+          "full_name": "gt-9.2.15-1.aarch64",
+          "specifier": ">"
+        },
+        {
+          "full_name": "ge-9.2.15-1.aarch64",
+          "specifier": ">="
+        },
+        {
+          "full_name": "default-9.2.15-1.aarch64"
         }
+
       ]
     }
   ]

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -111,6 +111,9 @@ class VerifierTestCase(unittest.TestCase):
 
         self.assertEqual(len(results), len(publisher.results))
 
-        self.assertEqual(set(), results.intersection(not_in_results))
+        self.assertEqual(
+            set(),
+            results.intersection(not_in_results),
+        )
 
         self.assertEqual(set(in_results), results.intersection(in_results))


### PR DESCRIPTION
 _check_package was returning when the check for a vulnerability is
negative that meant that if there were multiple architectures defined it
returns None although the wanted architecure in the list was not reached
yet.

In return there were missing vulnerabilities, this is fixed by changing
it to continue and verify on _start_scan if vulnerabilities within
vulnerability were found instead of relying on None.