### PR TITLE
Fix: version comparison in case of an `~`

### DIFF
--- a/notus/scanner/models/packages/package.py
+++ b/notus/scanner/models/packages/package.py
@@ -127,11 +127,17 @@ class Package:
                     if a_part.lower() > b_part.lower()
                     else PackageComparison.B_NEWER
                 )
-            if a_part.isalpha() or b_part.isalpha():
+            if a_part.isalpha():
                 return (
                     PackageComparison.A_NEWER
-                    if b_part.isalpha() or b_part == "~"
+                    if b_part == "~"
                     else PackageComparison.B_NEWER
+                )
+            if b_part.isalpha():
+                return (
+                    PackageComparison.B_NEWER
+                    if a_part == "~"
+                    else PackageComparison.A_NEWER
                 )
 
             return (

--- a/tests/models/packages/test_package.py
+++ b/tests/models/packages/test_package.py
@@ -133,6 +133,13 @@ class PackageTestCase(TestCase):
         ret = Package.version_compare(version_a, version_b)
         self.assertEqual(ret, PackageComparison.B_NEWER)
 
+        version_a = "20211016ubuntu0.20.04.1"
+        version_b = "20211016~20.04.1"
+        ret = Package.version_compare(version_a, version_b)
+        self.assertEqual(ret, PackageComparison.A_NEWER)
+        ret = Package.version_compare(version_a=version_b, version_b=version_a)
+        self.assertEqual(ret, PackageComparison.B_NEWER)
+
 
 class PackageAdvisoryTestCase(TestCase):
     def test_constructor(self):


### PR DESCRIPTION
**What**:
A small bug lead to a wrong version comparison in case one of the versions contained a `~` at the same position the other version contains a letter. In this case the version given first was always declared to be newer. This issue is fixed with this PR and a test is added for such a case.

SC-752

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:
Compare two versions such as `20211016ubuntu0.20.04.1` with `20211016~20.04.1`. The first should be always newer. In the old unfixed version the one used as base to compare was always newer.
This can be tested in the python shell:
```python
from notus.scanner.models.packages.package import Package

version_compare("20211016~20.04.1", "20211016ubuntu0.20.04.1")
# A_NEWER
version_compare("20211016ubuntu0.20.04.1", "20211016~20.04.1")
# Also A_NEWER
# The First one should be B_NEWER
``` 
The above example is fixed with the new patch

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/notus-scanner/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
