### PR TITLE
Change: Use `tomllib` for Python 3.11 and greater

### DIFF
--- a/notus/scanner/config.py
+++ b/notus/scanner/config.py
@@ -25,12 +25,12 @@ import sys
 from pathlib import Path
 from typing import Any, Dict
 
+from notus.scanner.errors import ConfigFileError
+
 if sys.version_info >= (3, 11):
     import tomllib as toml
 else:
     import tomli as toml
-
-from notus.scanner.errors import ConfigFileError
 
 logger = logging.getLogger(__name__)
 

--- a/notus/scanner/config.py
+++ b/notus/scanner/config.py
@@ -21,10 +21,14 @@ Module to store Notus Scanner configuration settings
 
 import logging
 import os
+import sys
 from pathlib import Path
 from typing import Any, Dict
 
-import tomli
+if sys.version_info >= (3, 11):
+    import tomllib as toml
+else:
+    import tomli as toml
 
 from notus.scanner.errors import ConfigFileError
 
@@ -70,12 +74,12 @@ class Config:
     def load(self, filepath: Path) -> None:
         try:
             content = filepath.read_text(encoding="utf-8")
-            config_data = tomli.loads(content)
+            config_data = toml.loads(content)
         except IOError as e:
             raise ConfigFileError(
                 f"Can't load config file {filepath.absolute()}. Error was {e}."
             ) from e
-        except tomli.TOMLDecodeError as e:
+        except toml.TOMLDecodeError as e:
             raise ConfigFileError(
                 f"Can't load config file. {filepath.absolute()} is not a valid "
                 "TOML file."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ paho-mqtt = ">=1.5.1"
 psutil = "^5.9"
 sentry-sdk = {version = "^1.14.0", optional = true}
 python-gnupg = "^0.5.0"
-tomli = "<3.0.0"
+tomli = {version = "<3.0.0", python = "<3.11"}
 packaging = "<23.1"
 
 [tool.poetry.extras]


### PR DESCRIPTION
**What**:

utilise tomllib over tomli for python3.11 and greater
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

avoids a dependency for newer python versions as it is part of the stdlib
<!-- Why are these changes necessary? -->

**How**:

load toml config

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests N/A
- [ ] [CHANGELOG](https://github.com/greenbone/notus-scanner/blob/master/CHANGELOG.md) Entry
- [ ] Documentation N/A
