### PR TITLE
Change: Use universal release action, not python specific

### DIFF
--- a/.github/workflows/release-pontos-manually.yml
+++ b/.github/workflows/release-pontos-manually.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Release with release action
       uses: greenbone/actions/release@v2
       with:
-        version: 3.8
+        python-version: 3.9
         conventional-commits: true
         github-user: ${{ secrets.GREENBONE_BOT }}
         github-user-mail: ${{ secrets.GREENBONE_BOT_MAIL }}

--- a/.github/workflows/release-pontos-manually.yml
+++ b/.github/workflows/release-pontos-manually.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
     - name: Release with release action
-      uses: greenbone/actions/release-python@v1
+      uses: greenbone/actions/release@v2
       with:
         version: 3.8
         conventional-commits: true

--- a/.github/workflows/release-pontos.yml
+++ b/.github/workflows/release-pontos.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Release with release action
       uses: greenbone/actions/release@v2
       with:
-        version: 3.8
+        python-version: 3.9
         conventional-commits: true
         ref: ${{ github.ref_name }}
         github-user: ${{ secrets.GREENBONE_BOT }}

--- a/.github/workflows/release-pontos.yml
+++ b/.github/workflows/release-pontos.yml
@@ -12,10 +12,11 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
     - name: Release with release action
-      uses: greenbone/actions/release-python@v1
+      uses: greenbone/actions/release@v2
       with:
         version: 3.8
         conventional-commits: true
+        ref: ${{ github.ref_name }}
         github-user: ${{ secrets.GREENBONE_BOT }}
         github-user-mail: ${{ secrets.GREENBONE_BOT_MAIL }}
         github-user-token: ${{ secrets.GREENBONE_BOT_TOKEN }}


### PR DESCRIPTION
**What** & **Why**:

<!-- Why are these changes necessary? -->
Instead of using greenbone/release-python@v2 we should switch to use greenbone/release@v2 everywhere, so we only need to maintain one release action.
Remove PR_TEMPLATE

**How**:

Magic. DEVOPS-539

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] Conventional commit message
- [ ] Documentation
