### PR TITLE
Fix: Missing default value and wrong default path in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -42,7 +42,7 @@ if you want to use a user specific configuration create it in `~/.config/notus-s
 [notus-scanner]
 mqtt-broker-address = "localhost"
 mqtt-broker-port = "1883"
-products-directory = "/var/lib/openvas/plugins/notus/products"
+products-directory = "/var/lib/notus/products"
 pid-file = "/var/run/notus-scanner/notus-scanner.pid"
 log-file = "/var/log/notus-scanner/notus-scanner.log"
 log-level = "INFO"
@@ -60,7 +60,7 @@ argument.
 |mqtt-broker-port|NOTUS_SCANNER_MQTT_BROKER_PORT|1883|Port of the MQTT broker|
 |pid-file|NOTUS_SCANNER_PID_FILE|/run/notus-scanner/notus-scanner.pid|File for storing the process ID|
 |products-directory|NOTUS_SCANNER_PRODUCTS_DIRECTORY|/var/lib/notus/products|Directory for loading product advisories|
-|disable-hashsum-verification| NOTUS_DISABLE_HASHSUM_VERIFICATION | To disable hashsum verification of products |
+|disable-hashsum-verification|NOTUS_DISABLE_HASHSUM_VERIFICATION|false|To disable hashsum verification of products|
 
 # Starting
 


### PR DESCRIPTION
## What

- Additional default path fix as a follow-up to #229
- See https://github.com/greenbone/notus-scanner/blob/67460623d1929c95b6fcf6b37986a9492ce1baf5/notus/scanner/config.py#L65 for the `false` default
- In the link above `False` can be seen but the example in https://github.com/greenbone/notus-scanner/blob/9c5588e43b25609db13033d6a373bb97d52a7ea0/INSTALL.md#configuration shows `false` so i took the latter. If `False` (uppercace `F`) is more correct it would need to be updated there as well

## Why

More correct / consistent info

## References

N/A