### PR TITLE
Install: Change "debian" to "Debian" in one description

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,7 +9,7 @@ Besides Python Notus Scanner also needs to have
 
 To retrieve package-lists and publish results Notus needs a MQTT broker running.
 
-To install a local MQTT-broker on debian you can execute:
+To install a local MQTT-broker on Debian you can execute:
 
 ```
 $ apt-get install mosquitto 


### PR DESCRIPTION
- Usually it`s Debian, not debian.
- No template or changelog entry for such a minor text change