### PR TITLE
Add: version ranges

### DIFF
--- a/notus/scanner/scanner.py
+++ b/notus/scanner/scanner.py
@@ -105,10 +105,8 @@ class NotusScanner:
                 package_advisory.package,
             )
             is_vulnerable = package_advisory.is_vulnerable(package)
-            if is_vulnerable is None:
+            if not is_vulnerable:
                 continue
-            elif not is_vulnerable:
-                return
 
             vul.add(package, package_advisory)
 
@@ -123,7 +121,9 @@ class NotusScanner:
 
         for package in installed_packages:
             package_advisory_oids = (
-                package_advisories.get_package_advisories_for_package(package)
+                package_advisories.get_package_advisories_for_package(
+                    package.name
+                )
             )
             for oid, package_advisory_list in package_advisory_oids.items():
                 vul = self._check_package(package, package_advisory_list)
@@ -171,9 +171,11 @@ class NotusScanner:
         if not package_advisories:
             # Probably a wrong or not supported OS-release
             logger.error(
-                "Unable to start scan for %s: No advisories for OS-release %s"
-                " found. Check if the OS-release is correct and the"
-                " corresponding advisories are given.",
+                (
+                    "Unable to start scan for %s: No advisories for OS-release"
+                    " %s found. Check if the OS-release is correct and the"
+                    " corresponding advisories are given."
+                ),
                 message.host_ip,
                 message.os_release,
             )
@@ -189,8 +191,10 @@ class NotusScanner:
         package_class = package_class_by_type(package_type)
         if not package_class:
             logger.error(
-                "Unable to start scan for %s: No package implementation for "
-                "OS-release %s found. Check if the OS-release is correct.",
+                (
+                    "Unable to start scan for %s: No package implementation for"
+                    " OS-release %s found. Check if the OS-release is correct."
+                ),
                 message.host_ip,
                 message.os_release,
             )

--- a/tests/loader/range.notus
+++ b/tests/loader/range.notus
@@ -1,0 +1,144 @@
+{
+    "version": "1.0",
+    "package_type": "deb",
+    "product_name": "Range Test",
+    "advisories": [
+        {
+            "oid": "1.3.6.1.4.1.25623.1.1.7.2.2023.10089729899100",
+            "fixed_packages": [
+                {
+                    "range": [
+                        {
+                            "name": "gitlab-ce",
+                            "full_version": "15.11.0",
+                            "specifier": "<"
+                        },
+                        {
+                            "name": "gitlab-ce",
+                            "full_version": "15.11.11",
+                            "specifier": ">="
+                        }
+                    ]
+                },
+                {
+                    "range": [
+                        {
+                            "name": "gitlab-ce",
+                            "full_version": "16.0.0",
+                            "specifier": "<"
+                        },
+                        {
+                            "name": "gitlab-ce",
+                            "full_version": "16.0.7",
+                            "specifier": ">="
+                        }
+                    ]
+                },
+                {
+                    "range": [
+                        {
+                            "name": "gitlab-ce",
+                            "full_version": "16.1.0",
+                            "specifier": "<"
+                        },
+                        {
+                            "name": "gitlab-ce",
+                            "full_version": "16.1.2",
+                            "specifier": ">="
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "oid": "1.3.6.1.4.1.25623.1.1.7.2.2023.0988598199100",
+            "fixed_packages": [
+                {
+                    "name": "grafana",
+                    "full_version": "8.5.24",
+                    "specifier": ">="
+                },
+                {
+                    "range": [
+                        {
+                            "name": "grafana",
+                            "full_version": "9.0.0",
+                            "specifier": "<"
+                        },
+                        {
+                            "name": "grafana",
+                            "full_version": "9.2.17",
+                            "specifier": ">="
+                        }
+                    ]
+                },
+                {
+                    "range": [
+                        {
+                            "name": "grafana",
+                            "full_version": "9.3.0",
+                            "specifier": "<"
+                        },
+                        {
+                            "name": "grafana",
+                            "full_version": "9.3.13",
+                            "specifier": ">="
+                        }
+                    ]
+                },
+                {
+                    "range": [
+                        {
+                            "name": "grafana",
+                            "full_version": "9.4.0",
+                            "specifier": "<"
+                        },
+                        {
+                            "name": "grafana",
+                            "full_version": "9.4.9",
+                            "specifier": ">="
+                        }
+                    ]
+                },
+                {
+                    "name": "grafana8",
+                    "full_version": "8.5.24",
+                    "specifier": ">="
+                },
+                {
+                    "name": "grafana9",
+                    "full_version": "9.2.17",
+                    "specifier": ">="
+                },
+                {
+                    "range": [
+                        {
+                            "name": "grafana9",
+                            "full_version": "9.3.0",
+                            "specifier": "<"
+                        },
+                        {
+                            "name": "grafana9",
+                            "full_version": "9.3.13",
+                            "specifier": ">="
+                        }
+                    ]
+                },
+                {
+                    "range": [
+                        {
+                            "name": "grafana9",
+                            "full_version": "9.4.0",
+                            "specifier": "<"
+                        },
+                        {
+                            "name": "grafana9",
+                            "full_version": "9.4.9",
+                            "specifier": ">="
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/tests/loader/test_json.py
+++ b/tests/loader/test_json.py
@@ -9,6 +9,7 @@ from unittest import TestCase
 from notus.scanner.errors import AdvisoriesLoadingError
 from notus.scanner.loader.gpg_sha_verifier import VerificationResult
 from notus.scanner.loader.json import JSONAdvisoriesLoader
+from notus.scanner.models.packages.deb import DEBPackage
 from notus.scanner.models.packages.rpm import RPMPackage
 
 _here = Path(__file__).parent
@@ -62,10 +63,10 @@ class JSONAdvisoriesLoaderTestCase(TestCase):
         if not package2:
             self.fail("package2 is None")
         package_advisories1 = advisories.get_package_advisories_for_package(
-            package1
+            package1.name
         )
         package_advisories2 = advisories.get_package_advisories_for_package(
-            package2
+            package2.name
         )
 
         oid = "1.3.6.1.4.1.25623.1.1.2.2016.1008"
@@ -88,6 +89,56 @@ class JSONAdvisoriesLoaderTestCase(TestCase):
         advisory = package_advisory1.oid
 
         self.assertEqual(advisory, "1.3.6.1.4.1.25623.1.1.2.2016.1008")
+
+    def test_example_range(self):
+        loader = JSONAdvisoriesLoader(
+            advisories_directory_path=_here,
+            verify=lambda _: VerificationResult.SUCCESS,
+        )
+
+        advisories = loader.load_package_advisories("range")
+        if not advisories:
+            self.fail("Advisories are none")
+        self.assertIsNotNone(advisories)
+        self.assertEqual(len(advisories), 4)
+
+        package1 = DEBPackage.from_name_and_full_version("gitlab-ce", "15.11.1")
+        if not package1:
+            self.fail("package1 is None")
+
+        package2 = DEBPackage.from_name_and_full_version("gitlab-ce", "15.10.1")
+        if not package2:
+            self.fail("package2 is None")
+        package_advisories = advisories.get_package_advisories_for_package(
+            package1.name
+        )
+
+        oid = "1.3.6.1.4.1.25623.1.1.7.2.2023.10089729899100"
+
+        self.assertEqual(len(package_advisories), 1)
+
+        self.assertIn(oid, package_advisories.keys())
+
+        package_advisories = package_advisories[oid]
+
+        # get first PackageAdvisory from the sets
+        package_advisory = next(iter(package_advisories))
+
+        advisory = package_advisory.oid
+
+        self.assertEqual(
+            advisory, "1.3.6.1.4.1.25623.1.1.7.2.2023.10089729899100"
+        )
+
+        vul_detect1 = 0
+        vul_detect2 = 0
+        for package_advisory in package_advisories:
+            if package_advisory.is_vulnerable(package1):
+                vul_detect1 += 1
+            if package_advisory.is_vulnerable(package2):
+                vul_detect2 += 1
+        self.assertEqual(2, vul_detect1)
+        self.assertEqual(0, vul_detect2)
 
     def test_invalid_package_type(self):
         loader = JSONAdvisoriesLoader(

--- a/tests/models/packages/test_package.py
+++ b/tests/models/packages/test_package.py
@@ -291,7 +291,7 @@ class PackageAdvisoriesTestCase(TestCase):
         )
         package_advisories.add_advisory_for_package(package, advisory, None)
         advisories = package_advisories.get_package_advisories_for_package(
-            other
+            other.name
         )
         self.assertEqual(1, len(advisories))
         for package_advisories in advisories.values():
@@ -347,10 +347,10 @@ class PackageAdvisoriesTestCase(TestCase):
         package_advisories.add_advisory_for_package(package2, advisory2, None)
 
         advisories1 = package_advisories.get_package_advisories_for_package(
-            package1
+            package1.name
         )
         advisories2 = package_advisories.get_package_advisories_for_package(
-            package2
+            package2.name
         )
         self.assertEqual(len(advisories1), 2)
         self.assertEqual(len(advisories2), 1)


### PR DESCRIPTION
Now it is possible to set a range for versions within a package is vulnerable

E.g.:
```json
{
    "version": "1.0",
    "package_type": "deb",
    "product_name": "Test OS",
    "advisories": [
        {
            "oid": "1.3.6.1.4.1.25623.1.1.7.2.2023.0988598199100",
            "fixed_packages": [
                {
                    "name": "grafana",
                    "full_version": "8.5.24",
                    "specifier": ">="
                },
                {
                    "range": [
                        {
                            "name": "grafana",
                            "full_version": "9.0.0",
                            "specifier": "<"
                        },
                        {
                            "name": "grafana",
                            "full_version": "9.2.17",
                            "specifier": ">="
                        }
                    ]
                },
                {
                    "range": [
                        {
                            "name": "grafana",
                            "full_version": "9.3.0",
                            "specifier": "<"
                        },
                        {
                            "name": "grafana",
                            "full_version": "9.3.13",
                            "specifier": ">="
                        }
                    ]
                }
            ]
        }
    ]
}
```

SC-894

