### PR TITLE
Add: Support authenticated connection to MQTT broker

### DIFF
--- a/notus/scanner/cli/parser.py
+++ b/notus/scanner/cli/parser.py
@@ -113,6 +113,25 @@ class CliParser:
             help="Port of the MQTT broker. (default: %(default)s)",
         )
         parser.add_argument(
+            "--mqtt-broker-username",
+            default=None,
+            type=str,
+            help=(
+                "Username to connect to MQTT broker for MQTT communication."
+                "Default %(default)s"
+            ),
+        )
+        parser.add_argument(
+            "--mqtt-broker-password",
+            default=None,
+            type=str,
+            help=(
+                "PASSWORD to connect to MQTT broker for MQTT communication."
+                "Default %(default)s"
+            ),
+        )
+
+        parser.add_argument(
             "--disable-hashsum-verification",
             type=bool,
             default=False,

--- a/notus/scanner/config.py
+++ b/notus/scanner/config.py
@@ -42,6 +42,16 @@ _CONFIG = (
         DEFAULT_MQTT_BROKER_ADDRESS,
     ),
     (
+        "mqtt-broker-username",
+        "NOTUS_SCANNER_MQTT_BROKER_USERNAME",
+        None,
+    ),
+    (
+        "mqtt-broker-password",
+        "NOTUS_SCANNER_MQTT_BROKER_PASSWORD",
+        None,
+    ),
+    (
         "mqtt-broker-port",
         "NOTUS_SCANNER_MQTT_BROKER_PORT",
         DEFAULT_MQTT_BROKER_PORT,

--- a/notus/scanner/daemon.py
+++ b/notus/scanner/daemon.py
@@ -63,6 +63,8 @@ def hashsum_verificator(
 def run_daemon(
     mqtt_broker_address: str,
     mqtt_broker_port: int,
+    mqtt_broker_username: str,
+    mqtt_broker_password: str,
     products_directory_path: Path,
     disable_hashsum_verification: bool,
 ):
@@ -87,6 +89,9 @@ def run_daemon(
         mqtt_broker_address=mqtt_broker_address,
         mqtt_broker_port=mqtt_broker_port,
     )
+    if mqtt_broker_username and mqtt_broker_password:
+        client.username_pw_set(mqtt_broker_username, mqtt_broker_password)
+
     daemon: MQTTDaemon
     try:
         daemon = MQTTDaemon(client)
@@ -130,6 +135,8 @@ def main():
     run_daemon(
         args.mqtt_broker_address,
         args.mqtt_broker_port,
+        args.mqtt_broker_username,
+        args.mqtt_broker_password,
         args.products_directory,
         args.disable_hashsum_verification,
     )


### PR DESCRIPTION
## What
Support authenticated connection to MQTT broker
If notus-scanner options --mqtt-broker-user and `--mqtt-broker-password are given (or configured in the notus-scanner.toml configuration file), the connection will be authenticated. For this to work, MQTT broker must be configured with valid user and pass. This is disable per default.

SC-917

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
Improvement
<!-- Describe why are these changes necessary? -->

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


