### PR TITLE
Change: use paho-mqtt version 2.0

### DIFF
--- a/notus/scanner/messaging/mqtt.py
+++ b/notus/scanner/messaging/mqtt.py
@@ -31,7 +31,11 @@ class MQTTClient(mqtt.Client):
         self._mqtt_broker_address = mqtt_broker_address
         self._mqtt_broker_port = mqtt_broker_port
 
-        super().__init__(client_id=client_id, protocol=mqtt.MQTTv5)
+        super().__init__(
+            mqtt.CallbackAPIVersion.VERSION1,
+            client_id=client_id,
+            protocol=mqtt.MQTTv5,
+        )
 
         self.enable_logger()
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -529,16 +529,17 @@ files = [
 
 [[package]]
 name = "paho-mqtt"
-version = "1.6.1"
+version = "2.0.0"
 description = "MQTT version 5.0/3.1.1 client class"
 optional = false
-python-versions = "*"
+python-versions = ">=3.7"
 files = [
-    {file = "paho-mqtt-1.6.1.tar.gz", hash = "sha256:2a8291c81623aec00372b5a85558a372c747cbca8e9934dfe218638b8eefc26f"},
+    {file = "paho_mqtt-2.0.0-py3-none-any.whl", hash = "sha256:2ef745073dfc9aa68bfec30d0b9b6f0304ea75182bae85a7c77a80cefce1eff5"},
+    {file = "paho_mqtt-2.0.0.tar.gz", hash = "sha256:13b205f29251e4f2c66a6c923c31fc4fd780561e03b2d775cff8e4f2915cf947"},
 ]
 
 [package.extras]
-proxy = ["PySocks"]
+proxy = ["pysocks"]
 
 [[package]]
 name = "pathspec"
@@ -824,4 +825,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "713e1bfe1e16d22c309ea09e8c1c1d92e29dd58facbcbb180743497a212498b0"
+content-hash = "5555aaa1e32c92f3c8e53d218e0288ab7a8cb9abe11ae812c7bf98c84617886e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
-# use v1.x due to https://github.com/eclipse/paho.mqtt.python/issues/814
-paho-mqtt = ">=1.6,<2.0"
+paho-mqtt = "^2.0"
 psutil = "^5.9"
 python-gnupg = "^0.5.1"
 tomli = { version = "<3.0.0", python = "<3.11" }


### PR DESCRIPTION
## What

Change: use paho-mqtt version 2.0 
Add the required parameter to Client() init

## Why

Support old callback API with paho-mqtt 2.0

## References
Jira: SC-1032
