### PR TITLE
Change: Support paho-mqtt version 1 and 2

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -902,4 +902,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "69acb6932f40ea7d0c72eab77fe54e1dbeb3e3875366eea7503697d254f92d05"
+content-hash = "6b7f3397e80eab0c381df8b5d975d5e48e453e469dc793eda84dca6847c1c072"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
-# use v1.x due to https://github.com/eclipse/paho.mqtt.python/issues/814
-paho-mqtt = ">=1.6,<2.0"
+paho-mqtt = ">=1.6,<3.0"
 psutil = "^5.9"
 python-gnupg = "^0.5.1"
 tomli = { version = "<3.0.0", python = "<3.11" }


### PR DESCRIPTION

## What

Support paho-mqtt version 1 and 2

## Why
For GOS we want to keep compatibility to paho-mqtt 1 but Kali for example already has switched to version 2. Therefore support both versions.