### PR TITLE
Fix: Use `ruff check` as linter

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           packages: notus tests
-          linter: ruff
+          linter: ruff check
 
   test:
     name: Run all tests


### PR DESCRIPTION
## What
Fix: Use `ruff check` as linter
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
Using `ruff` is deprecated ...
<!-- Describe why are these changes necessary? -->

## References 
DEVOPS-1093