### PR TITLE
Fix: notus deb package parsing

### DIFF
--- a/notus/scanner/models/packages/deb.py
+++ b/notus/scanner/models/packages/deb.py
@@ -12,10 +12,16 @@ from dataclasses import dataclass
 
 from .package import Package, PackageComparison
 
-_deb_compile = re.compile(r"(.*)-(?:(\d*):)?(\d.*)-(.*)")
-_deb_compile_wo_revision = re.compile(r"(.*)-(?:(\d*):)?(\d.*)")
-_deb_compile_version = re.compile(r"(?:(\d*):)?(\d.*)-(.*)")
-_deb_compile_version_wo_revision = re.compile(r"(?:(\d*):)?(\d.*)")
+_deb_compile = re.compile(
+    r"^([a-z0-9](?:[a-z0-9+-.])+)-(?:(\d*):)?(\d[\d\w+-.~]*)(?:-([\d\w+-.~]*))$"
+)
+_deb_compile_wo_revision = re.compile(
+    r"^([a-z0-9](?:[a-z0-9+-.])+)-(?:(\d*):)?(\d[\d\w+.~]*)$"
+)
+_deb_compile_version = re.compile(
+    r"^(?:(\d*):)?(\d[\d\w+-.~]*)(?:-([\d\w+-.~]*))$"
+)
+_deb_compile_version_wo_revision = re.compile(r"^(?:(\d*):)?(\d[\d\w+.~]*)$")
 
 
 logger = logging.getLogger(__name__)

--- a/tests/models/packages/test_deb.py
+++ b/tests/models/packages/test_deb.py
@@ -180,6 +180,17 @@ class DEBPackageTestCase(TestCase):
         self.assertEqual(package.debian_revision, "")
         self.assertEqual(package.full_name, "apport-symptoms-020")
 
+        package = DEBPackage.from_full_name(
+            "mariadb-server-10.6-1:10.6.18+maria~ubu2204"
+        )
+        self.assertEqual(package.name, "mariadb-server-10.6")
+        self.assertEqual(package.epoch, "1")
+        self.assertEqual(package.upstream_version, "10.6.18+maria~ubu2204")
+        self.assertEqual(package.debian_revision, "")
+        self.assertEqual(
+            package.full_name, "mariadb-server-10.6-1:10.6.18+maria~ubu2204"
+        )
+
     def test_from_name_and_full_version(self):
         """it should be possible to create packages from name and full
         version"""


### PR DESCRIPTION
The parsing inside notus scanner was done wrong in some cases, as the following example shows. Here a package with full name including the version of the installed package:
```
mariadb-server-10.6-1:10.6.18+maria~ubu2204
```
which should separate name and version into:
```
name: mariadb-server-10.6
version: 1:10.6.18+maria~ubu2204
```
but resulted in:
```
name: mariadb-server
version: 10.6-1:10.6.18+maria~ubu2204
```
which is not even a valid version at all.
Updating the regular expressions fixes this issue.
This issue came up in https://forum.greenbone.net/t/ubuntu-22-04-lts-mariadb-server-false-positive/18779
SC-1121