### PR TITLE
Change: URI result field defaults now to an empty string instead of None

### DIFF
--- a/notus/scanner/messages/result.py
+++ b/notus/scanner/messages/result.py
@@ -28,7 +28,7 @@ class ResultMessage(Message):
         oid: str,
         value: str,
         port: str = "package",
-        uri: str = None,
+        uri: str = "",
         result_type: ResultType = ResultType.ALARM,
         message_id: Optional[UUID] = None,
         group_id: Optional[UUID] = None,


### PR DESCRIPTION
## What
Change: URI result field defaults now to an empty string instead of None
gvmd will ignore/hide the URI field if it is an empty string.
Jira: SC-1197

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
None was later serialized and sent as string containing "None" in the URI result field. 

<!-- Describe why are these changes necessary? -->

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


