### PR TITLE
Change: Migrate release changelog generation from Pontos to git-cliff

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,41 +30,37 @@ on:
 # patch versions to 0.
 #
 # Major version releases are only valid on the "main" branch.
-# 
-# Once the version is found and enhanced, each __vewrsion__.py or project file is updated to the new
+#
+# Once the version is found and enhanced, each __version__.py or project file is updated to the new
 # version, and a commit is created in the found branch.
 jobs:
   release:
     name: release
     if: |
-        (github.event_name == 'workflow_dispatch') ||
+      (github.event_name == 'workflow_dispatch') ||
+      (
+        github.event.pull_request.merged == true &&
         (
-          github.event.pull_request.merged == true &&
-          ( 
-            contains(github.event.pull_request.labels.*.name, 'major_release') ||
-            contains(github.event.pull_request.labels.*.name, 'minor_release') ||
-            contains(github.event.pull_request.labels.*.name, 'patch_release')
-          )
+          contains(github.event.pull_request.labels.*.name, 'major_release') ||
+          contains(github.event.pull_request.labels.*.name, 'minor_release') ||
+          contains(github.event.pull_request.labels.*.name, 'patch_release')
         )
+      )
     runs-on: "ubuntu-latest"
     steps:
-      - name: set RELEASE_KIND = ${{ github.event.inputs.release }}
+      - name: Set RELEASE_KIND = ${{ github.event.inputs.release }}
         if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: |
-          echo "RELEASE_KIND=${{ github.event.inputs.release }}" >> $GITHUB_ENV
-      - name: set RELEASE_KIND = major
+        run: echo "RELEASE_KIND=${{ github.event.inputs.release }}" >> $GITHUB_ENV
+      - name: Set RELEASE_KIND = major
         if: ${{ (contains(github.event.pull_request.labels.*.name, 'major_release')) }}
-        run: |
-          echo "RELEASE_KIND=major" >> $GITHUB_ENV
-      - name: set RELEASE_KIND = minor
+        run: echo "RELEASE_KIND=major" >> $GITHUB_ENV
+      - name: Set RELEASE_KIND = minor
         if: ${{ (contains(github.event.pull_request.labels.*.name, 'minor_release')) }}
-        run: |
-          echo "RELEASE_KIND=minor" >> $GITHUB_ENV
-      - name: set RELEASE_KIND = patch
+        run: echo "RELEASE_KIND=minor" >> $GITHUB_ENV
+      - name: Set RELEASE_KIND = patch
         if: ${{ (contains(github.event.pull_request.labels.*.name, 'patch_release')) }}
-        run: |
-          echo "RELEASE_KIND=patch" >> $GITHUB_ENV
-      - name: set RELEASE_REF
+        run: echo "RELEASE_KIND=patch" >> $GITHUB_ENV
+      - name: Set RELEASE_REF
         run: |
           if [[ "${{ github.event_name }}" = "workflow_dispatch" ]]; then
             echo "RELEASE_REF=${{ github.ref_name }}" >> $GITHUB_ENV
@@ -75,14 +71,14 @@ jobs:
         with:
           token: ${{ secrets.GREENBONE_BOT_TOKEN }}
           fetch-depth: '0'
-      - name: "LATEST_VERSION"
+      - name: Get LATEST_VERSION
         run: |
           if [[ "${{ env.RELEASE_REF }}" = "main" ]]; then
             echo "LATEST_VERSION=$(git tag | grep "^v" | sed 's/^v//' | sort --version-sort | tail -n 1)" >> $GITHUB_ENV
           else
             echo "LATEST_VERSION=$(git tag | grep "^v${{ env.RELEASE_REF }}" | sed 's/^v//' | sort --version-sort | tail -n 1)" >> $GITHUB_ENV
           fi
-      - name: "default LATEST_VERSION"
+      - name: Default LATEST_VERSION
         run: |
           # default to 0.1.0 when there is no previous tag and on main branch
           if ([[ -z "${{ env.LATEST_VERSION }}" ]] &&  [[ "${{ env.RELEASE_REF }}" = "main" ]]); then
@@ -95,32 +91,27 @@ jobs:
         run: ([ -n "${{ env.LATEST_VERSION }}" ])
       - name: RELEASE_KIND != NULL
         run: ([ -n "${{ env.RELEASE_KIND }}" ])
-      - name: "NEW_VERSION"
+      - name: Calculate NEW_VERSION
         run: |
           echo "NEW_VERSION=$(sh .github/enhance_version.sh ${{ env.LATEST_VERSION }} ${{ env.RELEASE_KIND }})" >> $GITHUB_ENV
       - name: NEW_VERSION != NULL
         run: ([ -n "${{ env.NEW_VERSION }}" ])
-      - name: set git credentials
+      - name: Set git credentials
         run: |
-             git config --global user.email "${{ secrets.GREENBONE_BOT_MAIL }}"
-             git config --global user.name "${{ secrets.GREENBONE_BOT }}"
-      - name: "create working branch for previous major release (${{ env.LATEST_VERSION }})"
+          git config --global user.email "${{ secrets.GREENBONE_BOT_MAIL }}"
+          git config --global user.name "${{ secrets.GREENBONE_BOT }}"
+      - name: Create working branch for previous major release (${{ env.LATEST_VERSION }})
         if: ( env.RELEASE_KIND == 'major' )
         run: |
-          # save a branch so that we can easily create PR for that version when we want to fix something
           git checkout "v${{ env.LATEST_VERSION }}"
           export BRANCH_NAME=$(echo "${{ env.LATEST_VERSION }}" | sed 's/^\([0-9]*\).*/v\1/')
           git checkout -b "$BRANCH_NAME"
           git push origin "$BRANCH_NAME"
-      # create branch of version 
-      - name: prepare project version ${{ env.RELEASE_REF }} ${{ env.LATEST_VERSION }} -> ${{ env.NEW_VERSION }}
+      # create branch of version
+      - name: Prepare project version ${{ env.RELEASE_REF }} ${{ env.LATEST_VERSION }} -> ${{ env.NEW_VERSION }}
         run: |
-          # jump back for the case that we switched to a tag
           git checkout "${{ env.RELEASE_REF }}"
-          # install pontos
           python3 -m pip install pontos
-          #poetry install
-          #poetry shell
           pontos-version update ${{ env.NEW_VERSION }}
           if git diff --exit-code --quiet; then
             echo "There are no modified files, skipping."
@@ -131,28 +122,33 @@ jobs:
             git push origin ${{ env.RELEASE_REF }}
           fi
 
-      - run: mkdir assets/
-      - name: release ${{ env.LATEST_VERSION }} -> ${{ env.NEW_VERSION }}
+      - name: Create assets directory
+        run: mkdir -p assets/
+
+      # Install git-cliff 
+      - name: Install git-cliff
+        uses: greenbone/actions/uv@v3
+        with:
+          install: git-cliff
+
+      # Generate changelog with git-cliff
+      - name: Generate changelog with git-cliff
+        run: |
+          git-cliff -v --strip header -o /tmp/changelog.md --config cliff.toml --tag "${{ env.NEW_VERSION }}" "v${{ env.LATEST_VERSION }}..HEAD"
+          # Fallback if changelog is empty
+          if [ ! -s "/tmp/changelog.md" ]; then
+            echo "No release notes. See commit history for details." > /tmp/changelog.md
+          fi
+
+      # Create GitHub Release & Upload Assets
+      - name: Create GitHub Release & Upload Assets
+        env:
+          GH_TOKEN: ${{ secrets.GREENBONE_BOT_TOKEN }}
         run: |
           export PROJECT=$(echo "${{ github.repository }}" | sed 's/.*\///' )
-          pontos-changelog \
-            --current-version ${{ env.LATEST_VERSION }} \
-            --next-version ${{ env.NEW_VERSION }} \
-            --config changelog.toml \
-            --project $PROJECT \
-            --versioning-scheme semver \
-            -o /tmp/changelog.md   || true
-          # we would rather have empty release notes than no release
-          if [ ! -f "/tmp/changelog.md" ]; then
-            touch /tmp/changelog.md
-          fi
-          echo "${{ secrets.GREENBONE_BOT_TOKEN }}" | gh auth login --with-token
-          # lets see how smart it is
           export nrn="v${{ env.NEW_VERSION }}"
           export filename="$PROJECT-$nrn"
           gh release create "$nrn" -F /tmp/changelog.md
-          mkdir -p assets
-          ls -las assets/
           curl -Lo assets/$filename.zip https://github.com/${{ github.repository }}/archive/refs/tags/$nrn.zip
           curl -Lo assets/$filename.tar.gz https://github.com/${{ github.repository }}/archive/refs/tags/$nrn.tar.gz
           echo -e "${{ secrets.GPG_KEY }}" > private.pgp

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,87 @@
+[changelog]
+# template for the changelog header
+header = """
+# Changelog\n
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).\n
+"""
+# template for the changelog body
+# https://keats.github.io/tera/docs/#introduction
+body = """
+{%- macro remote_url() -%}
+  https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}
+{%- endmacro -%}
+
+{% if version -%}
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else -%}
+    ## [Unreleased]
+{% endif -%}
+
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | upper_first }}
+    {% for commit in commits %}
+        - {{ commit.message | split(pat="\n") | first | upper_first | trim }}\
+            {% if commit.remote.username %} by [@{{ commit.remote.username }}](https://github.com/{{ commit.remote.username }}){%- endif -%}
+            {% if commit.remote.pr_number %} in \
+            [#{{ commit.remote.pr_number }}]({{ self::remote_url() }}/pull/{{ commit.remote.pr_number }}) \
+            {% elif commit.id %} in \
+            [{{ commit.id | truncate(length=7, end="") }}]({{ self::remote_url() }}/commit/{{ commit.id }})\
+            {%- endif -%}
+    {% endfor %}
+{% endfor -%}
+"""
+# template for the changelog footer
+footer = """
+{%- macro remote_url() -%}
+  https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}
+{%- endmacro -%}
+
+{% for release in releases %}
+    {% if release.version -%}
+        {% if release.previous.version -%}
+            [{{ release.version | trim_start_matches(pat="v") }}]: \
+                {{ self::remote_url() }}/compare/{{ release.previous.version }}..{{ release.version }}
+        {% endif -%}
+    {% else -%}
+        [unreleased]: {{ self::remote_url() }}/compare/{{ release.previous.version }}..HEAD
+    {% endif -%}
+{%- endfor -%}
+"""
+# remove the leading and trailing whitespace from the templates
+trim = true
+
+[git]
+# parse the commits based on https://www.conventionalcommits.org
+conventional_commits = true
+# filter out the commits that are not following the conventional commits format
+filter_unconventional = false
+# process each line of a commit as an individual commit
+split_commits = false
+# regex for preprocessing the commit messages
+commit_preprocessors = [
+  # remove issue numbers from commits
+  { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "" },
+]
+# regex for parsing and grouping commits
+commit_parsers = [
+  { message = "^[a|A]dd", group = "<!-- 1 -->:sparkles: Added" },
+  { message = "^[c|C]hange", group = "<!-- 2 -->:construction_worker: Changed" },
+  { message = "^[f|F]ix", group = "<!-- 3 -->:bug: Bug Fixes" },
+  { message = "^[r|R]emove", group = "<!-- 4 -->:fire: Removed" },
+  { message = "^[d|D]rop", group = "<!-- 4 -->:fire: Removed" },
+  { message = "^[d|D]oc", group = "<!-- 5 -->:books: Documentation" },
+  { message = "^[t|T]est", group = "<!-- 6 -->:white_check_mark: Testing" },
+  { message = "^[c|C]hore", group = "<!-- 7 -->:wrench: Miscellaneous" },
+  { message = "^[c|C]i", group = "<!-- 7 -->️:wrench: Miscellaneous" },
+  { message = "^[m|M]isc", group = "<!-- 7 -->:wrench: Miscellaneous" },
+  { message = "^[d|D]eps", group = "<!-- 8 -->:ship: Dependencies" },
+]
+# filter out the commits that are not matched by commit parsers
+filter_commits = true
+# sort the tags topologically
+topo_order = false
+# sort the commits inside sections by oldest/newest order
+sort_commits = "oldest"


### PR DESCRIPTION
**What:**  
Replaced Pontos-based changelog generation with git-cliff in release workflows.

**Why:**  
To standardize and automate changelog generation, and remove the Pontos dependency.

**How:**  
- Updated release workflows to use git-cliff.
- Removed Pontos references and config files.
- Verified changelog output and workflow execution.

**Checklist:**  
-  Pontos removed
-  git-cliff added & tested
-  Docs updated

JIRA: [DOS-371](https://jira.greenbone.net/browse/DOS-371)